### PR TITLE
feat: Added Confidence Score for TextBlock/Line/Element

### DIFF
--- a/packages/google_mlkit_language_id/lib/src/language_identifier.dart
+++ b/packages/google_mlkit_language_id/lib/src/language_identifier.dart
@@ -23,9 +23,10 @@ class LanguageIdentifier {
   /// If no language could be determined then [undeterminedLanguageCode] is returned.
   /// More information: https://developers.google.com/ml-kit/language/identification
   Future<String> identifyLanguage(String text) async {
-    final result = await _channel.invokeMethod(
-        'nlp#startLanguageIdentifier', <String, dynamic>{
+    final result = await _channel
+        .invokeMethod('nlp#startLanguageIdentifier', <String, dynamic>{
       'text': text,
+      'id': id,
       'possibleLanguages': false,
       'confidence': confidenceThreshold
     });

--- a/packages/google_mlkit_language_id/lib/src/language_identifier.dart
+++ b/packages/google_mlkit_language_id/lib/src/language_identifier.dart
@@ -26,9 +26,9 @@ class LanguageIdentifier {
     final result = await _channel
         .invokeMethod('nlp#startLanguageIdentifier', <String, dynamic>{
       'text': text,
-      'id': id,
       'possibleLanguages': false,
-      'confidence': confidenceThreshold
+      'confidence': confidenceThreshold,
+      'id': id,
     });
 
     return result.toString();

--- a/packages/google_mlkit_text_recognition/android/src/main/java/com/google_mlkit_text_recognition/TextRecognizer.java
+++ b/packages/google_mlkit_text_recognition/android/src/main/java/com/google_mlkit_text_recognition/TextRecognizer.java
@@ -96,7 +96,9 @@ public class TextRecognizer implements MethodChannel.MethodCallHandler {
                                 block.getText(),
                                 block.getBoundingBox(),
                                 block.getCornerPoints(),
-                                block.getRecognizedLanguage());
+                                block.getRecognizedLanguage(), 
+                                null, 
+                                null);
 
                         List<Map<String, Object>> textLines = new ArrayList<>();
                         for (Text.Line line : block.getLines()) {
@@ -106,7 +108,9 @@ public class TextRecognizer implements MethodChannel.MethodCallHandler {
                                     line.getText(),
                                     line.getBoundingBox(),
                                     line.getCornerPoints(),
-                                    line.getRecognizedLanguage());
+                                    line.getRecognizedLanguage(), 
+                                    line.getConfidence(), 
+                                    line.getAngle());
 
                             List<Map<String, Object>> elementsData = new ArrayList<>();
                             for (Text.Element element : line.getElements()) {
@@ -116,7 +120,9 @@ public class TextRecognizer implements MethodChannel.MethodCallHandler {
                                         element.getText(),
                                         element.getBoundingBox(),
                                         element.getCornerPoints(),
-                                        element.getRecognizedLanguage());
+                                        element.getRecognizedLanguage(),
+                                        element.getConfidence(),
+                                        element.getAngle());
 
                                 elementsData.add(elementData);
                             }
@@ -136,7 +142,10 @@ public class TextRecognizer implements MethodChannel.MethodCallHandler {
                          String text,
                          Rect rect,
                          Point[] cornerPoints,
-                         String recognizedLanguage) {
+                         String recognizedLanguage, 
+                         Float confidence,
+                         Float angle
+                         ) {
         List<String> recognizedLanguages = new ArrayList<>();
         recognizedLanguages.add(recognizedLanguage);
         List<Map<String, Integer>> points = new ArrayList<>();
@@ -145,7 +154,10 @@ public class TextRecognizer implements MethodChannel.MethodCallHandler {
         addTo.put("rect", getBoundingPoints(rect));
         addTo.put("recognizedLanguages", recognizedLanguages);
         addTo.put("text", text);
+        addTo.put("confidence", confidence);
+        addTo.put("angle", angle);
     }
+
 
     private void addPoints(Point[] cornerPoints, List<Map<String, Integer>> points) {
         for (Point point : cornerPoints) {
@@ -156,6 +168,7 @@ public class TextRecognizer implements MethodChannel.MethodCallHandler {
         }
     }
 
+    
     private Map<String, Integer> getBoundingPoints(Rect rect) {
         Map<String, Integer> frame = new HashMap<>();
         frame.put("left", rect.left);

--- a/packages/google_mlkit_text_recognition/android/src/main/java/com/google_mlkit_text_recognition/TextRecognizer.java
+++ b/packages/google_mlkit_text_recognition/android/src/main/java/com/google_mlkit_text_recognition/TextRecognizer.java
@@ -158,7 +158,6 @@ public class TextRecognizer implements MethodChannel.MethodCallHandler {
         addTo.put("angle", angle);
     }
 
-
     private void addPoints(Point[] cornerPoints, List<Map<String, Integer>> points) {
         for (Point point : cornerPoints) {
             Map<String, Integer> p = new HashMap<>();
@@ -168,7 +167,6 @@ public class TextRecognizer implements MethodChannel.MethodCallHandler {
         }
     }
 
-    
     private Map<String, Integer> getBoundingPoints(Rect rect) {
         Map<String, Integer> frame = new HashMap<>();
         frame.put("left", rect.left);

--- a/packages/google_mlkit_text_recognition/ios/Classes/GoogleMlKitTextRecognitionPlugin.m
+++ b/packages/google_mlkit_text_recognition/ios/Classes/GoogleMlKitTextRecognitionPlugin.m
@@ -188,6 +188,8 @@
         },
         @"recognizedLanguages" : allLanguageData,
         @"text" : text,
+        @"confidence" : confidence,
+        @"angle" : angle,
     }];
 }
 

--- a/packages/google_mlkit_text_recognition/ios/Classes/GoogleMlKitTextRecognitionPlugin.m
+++ b/packages/google_mlkit_text_recognition/ios/Classes/GoogleMlKitTextRecognitionPlugin.m
@@ -115,7 +115,9 @@
              cornerPoints:block.cornerPoints
                     frame:block.frame
                 languages:block.recognizedLanguages
-                     text:block.text];
+                     text:block.text
+               confidence:NULL
+                    angle:NULL];
             
             NSMutableArray *textLines = [NSMutableArray array];
             for (MLKTextLine *line in block.lines) {
@@ -125,7 +127,9 @@
                  cornerPoints:line.cornerPoints
                         frame:line.frame
                     languages:line.recognizedLanguages
-                         text:line.text];
+                         text:line.text
+                   confidence:line.confidence
+                        angle:line.angle];
                 
                 NSMutableArray *elementsData = [NSMutableArray array];
                 for (MLKTextElement *element in line.elements) {
@@ -135,7 +139,9 @@
                      cornerPoints:element.cornerPoints
                             frame:element.frame
                         languages:NULL
-                             text:element.text];
+                             text:element.text
+                       confidence:element.confidence
+                            angle:element.angle];
                     
                     [elementsData addObject:elementData];
                 }
@@ -157,7 +163,9 @@
    cornerPoints:(NSArray<NSValue *> *)cornerPoints
           frame:(CGRect)frame
       languages:(NSArray<MLKTextRecognizedLanguage *> *)languages
-           text:(NSString *)text {
+           text:(NSString *)text
+     confidence:(NSNumber *)confidence
+          angle:(NSNumber *)angle {
     NSMutableArray *points = [NSMutableArray array];
     for (NSValue *point in cornerPoints) {
         [points addObject:@{ @"x" : @(point.CGPointValue.x),

--- a/packages/google_mlkit_text_recognition/lib/src/text_recognizer.dart
+++ b/packages/google_mlkit_text_recognition/lib/src/text_recognizer.dart
@@ -83,12 +83,6 @@ class TextBlock {
   /// List of corner points of the text block in clockwise order starting with the top left point relative to the image in the default coordinate space.
   final List<Point<int>> cornerPoints;
 
-  // The confidence of the recognized block.
-  final double confidence;
-
-  // The angle of the rotation of the recognized block.
-  final double angle;
-
   /// Constructor to create an instance of [TextBlock].
   TextBlock({
     required this.text,
@@ -96,16 +90,12 @@ class TextBlock {
     required this.boundingBox,
     required this.recognizedLanguages,
     required this.cornerPoints,
-    required this.confidence,
-    required this.angle,
   });
 
   /// Returns an instance of [TextBlock] from a given [json].
   factory TextBlock.fromJson(Map<dynamic, dynamic> json) {
     final text = json['text'];
     final rect = RectJson.fromJson(json['rect']);
-    final confidence = json['confidence'];
-    final angle = json['angle'];
     final recognizedLanguages =
         _listToRecognizedLanguages(json['recognizedLanguages']);
     final points = _listToCornerPoints(json['points']);
@@ -120,8 +110,6 @@ class TextBlock {
       boundingBox: rect,
       recognizedLanguages: recognizedLanguages,
       cornerPoints: points,
-      confidence: confidence,
-      angle: angle,
     );
   }
 }
@@ -197,18 +185,35 @@ class TextElement {
   /// List of corner points of the text element in clockwise order starting with the top left point relative to the image in the default coordinate space.
   final List<Point<int>> cornerPoints;
 
+  // The confidence of the recognized block.
+  final double confidence;
+
+  // The angle of the rotation of the recognized block.
+  final double angle;
+
   /// Constructor to create an instance of [TextElement].
-  TextElement(
-      {required this.text,
-      required this.boundingBox,
-      required this.cornerPoints});
+  TextElement({
+    required this.text,
+    required this.boundingBox,
+    required this.cornerPoints,
+    required this.confidence,
+    required this.angle,
+  });
 
   /// Returns an instance of [TextElement] from a given [json].
   factory TextElement.fromJson(Map<dynamic, dynamic> json) {
     final text = json['text'];
     final rect = RectJson.fromJson(json['rect']);
     final points = _listToCornerPoints(json['points']);
-    return TextElement(text: text, boundingBox: rect, cornerPoints: points);
+    final confidence = json['confidence'];
+    final angle = json['angle'];
+    return TextElement(
+      text: text,
+      boundingBox: rect,
+      cornerPoints: points,
+      confidence: confidence,
+      angle: angle,
+    );
   }
 }
 

--- a/packages/google_mlkit_text_recognition/lib/src/text_recognizer.dart
+++ b/packages/google_mlkit_text_recognition/lib/src/text_recognizer.dart
@@ -83,18 +83,29 @@ class TextBlock {
   /// List of corner points of the text block in clockwise order starting with the top left point relative to the image in the default coordinate space.
   final List<Point<int>> cornerPoints;
 
+  // The confidence of the recognized block.
+  final double confidence;
+
+  // The angle of the rotation of the recognized block.
+  final double angle;
+
   /// Constructor to create an instance of [TextBlock].
-  TextBlock(
-      {required this.text,
-      required this.lines,
-      required this.boundingBox,
-      required this.recognizedLanguages,
-      required this.cornerPoints});
+  TextBlock({
+    required this.text,
+    required this.lines,
+    required this.boundingBox,
+    required this.recognizedLanguages,
+    required this.cornerPoints,
+    required this.confidence,
+    required this.angle,
+  });
 
   /// Returns an instance of [TextBlock] from a given [json].
   factory TextBlock.fromJson(Map<dynamic, dynamic> json) {
     final text = json['text'];
     final rect = RectJson.fromJson(json['rect']);
+    final confidence = json['confidence'];
+    final angle = json['angle'];
     final recognizedLanguages =
         _listToRecognizedLanguages(json['recognizedLanguages']);
     final points = _listToCornerPoints(json['points']);
@@ -104,11 +115,14 @@ class TextBlock {
       lines.add(textLine);
     }
     return TextBlock(
-        text: text,
-        lines: lines,
-        boundingBox: rect,
-        recognizedLanguages: recognizedLanguages,
-        cornerPoints: points);
+      text: text,
+      lines: lines,
+      boundingBox: rect,
+      recognizedLanguages: recognizedLanguages,
+      cornerPoints: points,
+      confidence: confidence,
+      angle: angle,
+    );
   }
 }
 
@@ -129,18 +143,29 @@ class TextLine {
   /// The corner points of the text line in clockwise order starting with the top left point relative to the image in the default coordinate space.
   final List<Point<int>> cornerPoints;
 
+  // The confidence of the recognized block.
+  final double confidence;
+
+  // The angle of the rotation of the recognized line.
+  final double angle;
+
   /// Constructor to create an instance of [TextLine].
-  TextLine(
-      {required this.text,
-      required this.elements,
-      required this.boundingBox,
-      required this.recognizedLanguages,
-      required this.cornerPoints});
+  TextLine({
+    required this.text,
+    required this.elements,
+    required this.boundingBox,
+    required this.recognizedLanguages,
+    required this.cornerPoints,
+    required this.confidence,
+    required this.angle,
+  });
 
   /// Returns an instance of [TextLine] from a given [json].
   factory TextLine.fromJson(Map<dynamic, dynamic> json) {
     final text = json['text'];
     final rect = RectJson.fromJson(json['rect']);
+    final confidence = json['confidence'];
+    final angle = json['angle'];
     final recognizedLanguages =
         _listToRecognizedLanguages(json['recognizedLanguages']);
     final points = _listToCornerPoints(json['points']);
@@ -150,11 +175,14 @@ class TextLine {
       elements.add(textElement);
     }
     return TextLine(
-        text: text,
-        elements: elements,
-        boundingBox: rect,
-        recognizedLanguages: recognizedLanguages,
-        cornerPoints: points);
+      text: text,
+      elements: elements,
+      boundingBox: rect,
+      recognizedLanguages: recognizedLanguages,
+      cornerPoints: points,
+      confidence: confidence,
+      angle: angle,
+    );
   }
 }
 


### PR DESCRIPTION
@fbernaly based on #448 issue to add confidence score for TextBlock/Line/Element on `google_mlkit_text_recognition`. 
Just added the `confidence score` and `angle`. However, TextBlock doesn't give these two on the [ML kit doc](https://developers.google.com/android/reference/com/google/mlkit/vision/text/Text.TextBlock)  
Also `google_mlkit_language_id` fix the missing id for `identifyLanguage` 
