### PR TITLE
fix(entity extraction): actually set reference time when time paramet…

### DIFF
--- a/packages/google_mlkit_entity_extraction/android/src/main/java/com/google_mlkit_entity_extraction/EntityExtractor.java
+++ b/packages/google_mlkit_entity_extraction/android/src/main/java/com/google_mlkit_entity_extraction/EntityExtractor.java
@@ -87,10 +87,16 @@ public class EntityExtractor implements MethodChannel.MethodCallHandler {
             timeZone = TimeZone.getTimeZone((String) parameters.get("timezone"));
         }
 
+        Long referenceTime = null;
+        if (parameters.get("time") != null) {
+            referenceTime = (Long) parameters.get("time");
+        }
+
         EntityExtractionParams params = new EntityExtractionParams.Builder(text)
                 .setEntityTypesFilter(filters)
                 .setPreferredLocale(locale)
                 .setReferenceTimeZone(timeZone)
+                .setReferenceTime(referenceTime)
                 .build();
 
         entityExtractor

--- a/packages/google_mlkit_entity_extraction/ios/Classes/GoogleMlKitEntityExtractionPlugin.m
+++ b/packages/google_mlkit_entity_extraction/ios/Classes/GoogleMlKitEntityExtractionPlugin.m
@@ -60,6 +60,12 @@
     if ([timezone isKindOfClass: [NSString class]] && timezone.length > 0) {
         params.referenceTimeZone = [NSTimeZone timeZoneWithAbbreviation:timezone];
     }
+
+    NSString *time = parameters[@"time"];
+    if ([time isKindOfClass: [NSNumber class]]) {
+        // NSTimeInterval should is expressed in seconds, not milliseconds
+        params.referenceTime = [NSDate dateWithTimeIntervalSince1970: time.doubleValue / 1000];
+    }
     
     NSString *locale = parameters[@"locale"];
     if ([locale isKindOfClass: [NSString class]] && locale.length > 0) {

--- a/packages/google_mlkit_entity_extraction/lib/src/entity_extractor.dart
+++ b/packages/google_mlkit_entity_extraction/lib/src/entity_extractor.dart
@@ -17,6 +17,8 @@ class EntityExtractor {
 
   /// Annotates the given text with the given parameters such as reference time, preferred locale, reference time zone and entity types filter.
   /// Returns a list of [EntityAnnotation] or returns empty list if there is no identified entity.
+  ///
+  /// [referenceTime] should be expressed in milliseconds since epoch.
   Future<List<EntityAnnotation>> annotateText(
     String text, {
     int? referenceTime,


### PR DESCRIPTION
This PR adds missing bits to `google_mlkit_entity_extraction`, which documents a parameter without actually passing it to ML Kit on the platform side.

When the `time` parameter is passed to `EntityExtractor.annotateText`, the reference time for extracting relative dates such as "tomorrow" is actually set.

Fixes #452 