### PR TITLE
fix: Barcode scanner rect - null if nothing found

### DIFF
--- a/packages/example/lib/vision_detector_views/painters/barcode_detector_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/barcode_detector_painter.dart
@@ -43,21 +43,21 @@ class BarcodeDetectorPainter extends CustomPainter {
       builder.pop();
 
       final left = translateX(
-        barcode.boundingBox.left,
+        barcode.boundingBox!.left.toDouble(),
         size,
         imageSize,
         rotation,
         cameraLensDirection,
       );
       final top = translateY(
-        barcode.boundingBox.top,
+        barcode.boundingBox!.top.toDouble(),
         size,
         imageSize,
         rotation,
         cameraLensDirection,
       );
       final right = translateX(
-        barcode.boundingBox.right,
+        barcode.boundingBox!.right.toDouble(),
         size,
         imageSize,
         rotation,

--- a/packages/example/pubspec.yaml
+++ b/packages/example/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_barcode_scanning/lib/src/barcode_scanner.dart
+++ b/packages/google_mlkit_barcode_scanning/lib/src/barcode_scanner.dart
@@ -207,7 +207,9 @@ class Barcode {
   final Uint8List? rawBytes;
 
   /// The rectangle that holds the discovered barcode relative to the detected image in the view coordinate system.
-  final Rect boundingBox;
+  ///
+  /// Null if nothing found
+  final Rect? boundingBox;
 
   /// The four corner points of the barcode, in clockwise order starting with the top left relative to the detected image in the view coordinate system.
   ///


### PR DESCRIPTION
#490 
Based on this issue
Rect can return null  
( https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/common/Barcode#public-rect-getboundingbox ) 

And also updated the example SDK, all the packages use `>=2.16.0 <3.0.0`

