### PR TITLE
fix: iOS Named Entity Extraction - Milliseconds Failure

### DIFF
--- a/packages/google_mlkit_entity_extraction/ios/Classes/GoogleMlKitEntityExtractionPlugin.m
+++ b/packages/google_mlkit_entity_extraction/ios/Classes/GoogleMlKitEntityExtractionPlugin.m
@@ -155,7 +155,8 @@
                     } else if ([entity.entityType isEqualToString: MLKEntityExtractionEntityTypeDateTime]) {
                         type = 2;
                         entityData[@"dateTimeGranularity"] = @(entity.dateTimeEntity.dateTimeGranularity);
-                        entityData[@"timestamp"] = @(entity.dateTimeEntity.dateTime.timeIntervalSince1970);
+                        // result is expected in milliseconds, not seconds.
+                        entityData[@"timestamp"] = @(entity.dateTimeEntity.dateTime.timeIntervalSince1970 * 1000);
                     } else if ([entity.entityType isEqualToString: MLKEntityExtractionEntityTypeEmail]) {
                         type = 3;
                     } else if ([entity.entityType isEqualToString: MLKEntityExtractionEntityTypeFlightNumber]) {


### PR DESCRIPTION
On iOS, named entities of type DateTime return timestamps in seconds since Epoch 1970. Flutter expects value in milliseconds since Epoch 1970.

*How to Test*

Build Example App on iOS. Go to Nlp, Entity Extraction and Enter '01.06.2023'. Change Code of Example App as described below. Before change,  DateTime.fromMillisecondsSinceEpoch will return DateTime where Year is like 1970. After Change, the Date has the correct year, month and day.  

Change Code in Example App
```
        ListView.builder(
                  padding: const EdgeInsets.symmetric(horizontal: 10),
                  shrinkWrap: true,
                  physics: NeverScrollableScrollPhysics(),
                  itemCount: _entities.length,
                  itemBuilder: (context, index) => ExpansionTile(
                      title: Text(_entities[index].text),
                      children: _entities[index]
                          .entities
                          .map((e) => Text('${e.type.name}: $e'))
                          .toList()),
                ),
```
to

```
                ListView.builder(
                  padding: const EdgeInsets.symmetric(horizontal: 10),
                  shrinkWrap: true,
                  physics: NeverScrollableScrollPhysics(),
                  itemCount: _entities.length,
                  itemBuilder: (context, index) => ExpansionTile(
                      title: Text(_entities[index].text),
                      children: _entities[index].entities.map((e) {
                        if (e is DateTimeEntity) {
                          return Text(
                              DateTime.fromMillisecondsSinceEpoch(e.timestamp)
                                  .toString());
                        }

                        return Text('${e.type.name}: $e');
                      }).toList()),
                ),
```