### PR TITLE
refactor(example): use `ColoredBox` over `Container`

### DIFF
--- a/packages/example/lib/vision_detector_views/camera_view.dart
+++ b/packages/example/lib/vision_detector_views/camera_view.dart
@@ -76,7 +76,7 @@ class _CameraViewState extends State<CameraView> {
     if (_cameras.isEmpty) return Container();
     if (_controller == null) return Container();
     if (_controller?.value.isInitialized == false) return Container();
-    return Container(
+    return ColoredBox(
       color: Colors.black,
       child: Stack(
         fit: StackFit.expand,


### PR DESCRIPTION
Update example to use a simpler widget `ColoredBox` over `Container`, see the ["user_colored_box"](https://dart.dev/tools/linter-rules/use_colored_box) Dart Rule.