### PR TITLE
update BarcodeScanning  dependency

### DIFF
--- a/packages/google_mlkit_barcode_scanning/ios/google_mlkit_barcode_scanning.podspec
+++ b/packages/google_mlkit_barcode_scanning/ios/google_mlkit_barcode_scanning.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'GoogleMLKit/BarcodeScanning', '~> 5.0.0'
+  s.dependency 'GoogleMLKit/BarcodeScanning', '~> 6.0.0'
   s.dependency 'google_mlkit_commons'
   s.platform = :ios, '12.0'
   s.ios.deployment_target = '12.0'


### PR DESCRIPTION
Needed to update the dependency because I work on a project that uses google_mlkit_barcode_scanning and also mobile_scanner, 

the problem was caused because they were using different versions of BarcodeScanning

https://github.com/flutter-ml/google_ml_kit_flutter/blob/develop/packages/google_mlkit_barcode_scanning/ios/google_mlkit_barcode_scanning.podspec#L18
https://github.com/juliansteenbakker/mobile_scanner/blob/master/ios/mobile_scanner.podspec#L18


And would return this error
[!] CocoaPods could not find compatible versions for pod "GoogleMLKit/BarcodeScanning":
  In Podfile:
    google_mlkit_barcode_scanning (from `.symlinks/plugins/google_mlkit_barcode_scanning/ios`) was resolved to 0.11.1, which depends on
      GoogleMLKit/BarcodeScanning (~> 5.0.0)

    mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`) was resolved to 5.0.0, which depends on
      GoogleMLKit/BarcodeScanning (~> 6.0.0)
      
 As this was the project that was lagging behind I decided to update and for me it worked