### PR TITLE
feat: Support more image formats on Android

### DIFF
--- a/packages/google_mlkit_commons/CHANGELOG.md
+++ b/packages/google_mlkit_commons/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.2
+
+* Widened image format support for Android
+* Improve documentation for image formats
+
 ## 0.7.1
 
 * Update README.

--- a/packages/google_mlkit_commons/android/src/main/java/com/google_mlkit_commons/InputImageConverter.java
+++ b/packages/google_mlkit_commons/android/src/main/java/com/google_mlkit_commons/InputImageConverter.java
@@ -37,7 +37,7 @@ public class InputImageConverter {
                     (int) (double) metaData.get("width"),
                     (int) (double) metaData.get("height"),
                     (int) metaData.get("rotation"),
-                    (int) imageData.get("image_format"));
+                    (int) metaData.get("image_format"));
             return inputImage;
         } else {
             result.error("InputImageConverterError", "Invalid Input Image", null);

--- a/packages/google_mlkit_commons/android/src/main/java/com/google_mlkit_commons/InputImageConverter.java
+++ b/packages/google_mlkit_commons/android/src/main/java/com/google_mlkit_commons/InputImageConverter.java
@@ -37,7 +37,7 @@ public class InputImageConverter {
                     (int) (double) metaData.get("width"),
                     (int) (double) metaData.get("height"),
                     (int) metaData.get("rotation"),
-                    InputImage.IMAGE_FORMAT_NV21);
+                    (int) imageData.get("image_format"));
             return inputImage;
         } else {
             result.error("InputImageConverterError", "Invalid Input Image", null);

--- a/packages/google_mlkit_commons/lib/src/input_image.dart
+++ b/packages/google_mlkit_commons/lib/src/input_image.dart
@@ -62,11 +62,15 @@ class InputImageMetadata {
 
   /// Format of the input image.
   ///
-  /// Android only supports
+  /// Android supports
   /// - [InputImageFormat.nv21]
   /// - [InputImageFormat.yuv_420_888]
   /// - [InputImageFormat.yv12]
   /// as described in [here](https://developers.google.com/android/reference/com/google/mlkit/vision/common/InputImage.ImageFormat).
+  ///
+  /// iOS supports
+  /// - [InputImageFormat.yuv420]
+  /// - [InputImageFormat.bgra8888]
   final InputImageFormat format;
 
   /// The row stride for color plane, in bytes.
@@ -126,10 +130,19 @@ extension InputImageRotationValue on InputImageRotation {
 
 /// To indicate the format of image while creating input image from bytes
 enum InputImageFormat {
+  /// Android only: https://developers.google.com/android/reference/com/google/mlkit/vision/common/InputImage#IMAGE_FORMAT_NV21
   nv21,
+
+  /// Android only: https://developers.google.com/android/reference/com/google/mlkit/vision/common/InputImage#public-static-final-int-image_format_yv12
   yv12,
+
+  /// Android only: https://developers.google.com/android/reference/com/google/mlkit/vision/common/InputImage#public-static-final-int-image_format_yuv_420_888
   yuv_420_888,
+
+  /// iOS only: https://developer.apple.com/documentation/corevideo/kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
   yuv420,
+
+  /// iOS only: https://developer.apple.com/documentation/corevideo/kcvpixelformattype_32bgra
   bgra8888,
 }
 

--- a/packages/google_mlkit_commons/lib/src/input_image.dart
+++ b/packages/google_mlkit_commons/lib/src/input_image.dart
@@ -62,7 +62,11 @@ class InputImageMetadata {
 
   /// Format of the input image.
   ///
-  /// Not used on Android.
+  /// Android only supports
+  /// - [InputImageFormat.nv21]
+  /// - [InputImageFormat.yuv_420_888]
+  /// - [InputImageFormat.yv12]
+  /// as described in [here](https://developers.google.com/android/reference/com/google/mlkit/vision/common/InputImage.ImageFormat).
   final InputImageFormat format;
 
   /// The row stride for color plane, in bytes.

--- a/packages/google_mlkit_commons/pubspec.yaml
+++ b/packages/google_mlkit_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_mlkit_commons
 description: A Flutter plugin with commons files to implement google's standalone ml kit made for mobile platform.
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 
 environment:


### PR DESCRIPTION
Instead of hardcoding a specific format, we're now properly using the correct format as specified on the Dart side.


In case an invalid image format was used, this throws the following exception:
```
PlatformException(error, null, null, java.lang.IllegalArgumentException
	at com.google.android.gms.common.internal.Preconditions.checkArgument(com.google.android.gms:play-services-basement@@18.3.0:1)
	at com.google.mlkit.vision.common.InputImage.<init>(com.google.mlkit:vision-common@@17.3.0:7)
	at com.google.mlkit.vision.common.InputImage.fromByteArray(com.google.mlkit:vision-common@@17.3.0:2)
	at com.google_mlkit_commons.InputImageConverter.getInputImageFromData(InputImageConverter.java:36)
	at com.google_mlkit_barcode_scanning.BarcodeScanner.handleDetection(BarcodeScanner.java:70)
	at com.google_mlkit_barcode_scanning.BarcodeScanner.onMethodCall(BarcodeScanner.java:41)
	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:267)
	at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:292)
	at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:319)
	at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(Unknown Source:12)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:210)
	at android.os.Looper.loop(Looper.java:299)
	at android.app.ActivityThread.main(ActivityThread.java:8168)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:556)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1037)
)
```