### PR TITLE
feat: Subject Segmentation - added SubjectSegmenterOptions

### DIFF
--- a/packages/example/lib/vision_detector_views/painters/subject_segmentation_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/subject_segmentation_painter.dart
@@ -21,7 +21,7 @@ class SubjectSegmentationPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final int width = mask.width;
     final int height = mask.height;
-    final List<Subject> subjects = mask.subjects;
+    final List<Subject> subjects = mask.subjects ?? [];
 
     final paint = Paint()..style = PaintingStyle.fill;
 
@@ -30,7 +30,7 @@ class SubjectSegmentationPainter extends CustomPainter {
       final int startY = subject.startY;
       final int subjectWidth = subject.subjectWidth;
       final int subjectHeight = subject.subjectHeight;
-      final List<double> confidences = subject.confidences;
+      final List<double> confidences = subject.confidences ?? [];
 
       for (int y = 0; y < subjectHeight; y++) {
         for (int x = 0; y < subjectWidth; x++) {

--- a/packages/example/lib/vision_detector_views/subject_segmenter_view.dart
+++ b/packages/example/lib/vision_detector_views/subject_segmenter_view.dart
@@ -12,7 +12,7 @@ class SubjectSegmenterView extends StatefulWidget {
 
 class _SubjectSegmenterViewState extends State<SubjectSegmenterView> {
   final SubjectSegmenter _segmenter = SubjectSegmenter(
-      options: SubjectSegmenterOptions(enableForegroundBitmap: true));
+      options: SubjectSegmenterOptions(enableForegroundConfidenceMask: true));
   bool _canProcess = true;
   bool _isBusy = false;
   CustomPaint? _customPaint;
@@ -57,8 +57,7 @@ class _SubjectSegmenterViewState extends State<SubjectSegmenterView> {
       _customPaint = CustomPaint(painter: painter);
     } else {
       // TODO: set _customPaint to draw on top of image
-      _text = 'There is a mask with ${mask.subjects.length} subjects';
-
+      _text = 'There is a mask with ${mask.subjects?.length} subjects';
       _customPaint = null;
     }
     _isBusy = false;

--- a/packages/example/lib/vision_detector_views/subject_segmenter_view.dart
+++ b/packages/example/lib/vision_detector_views/subject_segmenter_view.dart
@@ -11,7 +11,8 @@ class SubjectSegmenterView extends StatefulWidget {
 }
 
 class _SubjectSegmenterViewState extends State<SubjectSegmenterView> {
-  final SubjectSegmenter _segmenter = SubjectSegmenter();
+  final SubjectSegmenter _segmenter = SubjectSegmenter(
+      options: SubjectSegmenterOptions(enableForegroundBitmap: true));
   bool _canProcess = true;
   bool _isBusy = false;
   CustomPaint? _customPaint;

--- a/packages/google_mlkit_subject_segmentation/README.md
+++ b/packages/google_mlkit_subject_segmentation/README.md
@@ -81,7 +81,8 @@ final InputImage inputImage;
 #### Create an instance of `SubjectSegmenter`
 
 ```dart
-final segmenter = SubjectSegmenter();
+final options = SubjectSegmenterOptions();
+final segmenter = SubjectSegmenter(options: options);
 ```
 
 #### Process image

--- a/packages/google_mlkit_subject_segmentation/android/build.gradle
+++ b/packages/google_mlkit_subject_segmentation/android/build.gradle
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation 'com.google.android.gms:play-services-mlkit-subject-segmentation:16.0.0-beta1'
-    implementation files('/Users/bensonarafat/development/flutter/bin/cache/artifacts/engine/android-arm/flutter.jar')
+//    implementation files('/Users/bensonarafat/development/flutter/bin/cache/artifacts/engine/android-arm/flutter.jar')
 }

--- a/packages/google_mlkit_subject_segmentation/android/build.gradle
+++ b/packages/google_mlkit_subject_segmentation/android/build.gradle
@@ -41,4 +41,5 @@ android {
 
 dependencies {
     implementation 'com.google.android.gms:play-services-mlkit-subject-segmentation:16.0.0-beta1'
+    implementation files('/Users/bensonarafat/development/flutter/bin/cache/artifacts/engine/android-arm/flutter.jar')
 }

--- a/packages/google_mlkit_subject_segmentation/android/build.gradle
+++ b/packages/google_mlkit_subject_segmentation/android/build.gradle
@@ -41,5 +41,4 @@ android {
 
 dependencies {
     implementation 'com.google.android.gms:play-services-mlkit-subject-segmentation:16.0.0-beta1'
-//    implementation files('/Users/bensonarafat/development/flutter/bin/cache/artifacts/engine/android-arm/flutter.jar')
 }

--- a/packages/google_mlkit_subject_segmentation/android/src/main/java/com/google_mlkit_subject_segmentation/SubjectSegmenterProcess.java
+++ b/packages/google_mlkit_subject_segmentation/android/src/main/java/com/google_mlkit_subject_segmentation/SubjectSegmenterProcess.java
@@ -35,8 +35,6 @@ public class SubjectSegmenterProcess implements MethodChannel.MethodCallHandler 
     private static final String CLOSE = "vision#closeSubjectSegmenter";
 
     private final Context context;
-
-    private static final String TAG = "Logger";
      
     private int imageWidth;
     private int imageHeight;
@@ -64,8 +62,10 @@ public class SubjectSegmenterProcess implements MethodChannel.MethodCallHandler 
     }
 
     private void handleDetection(MethodCall call, MethodChannel.Result result) {
-        InputImage inputImage = InputImageConverter.getInputImageFromData(call.argument("imageDate"), context, result);
+        InputImage inputImage = InputImageConverter.getInputImageFromData(call.argument("imageData"), context, result);
         if(inputImage == null) return;
+        imageHeight = inputImage.getHeight();
+        imageWidth = inputImage.getWidth();
 
         String id = call.argument("id");
         SubjectSegmenter subjectSegmenter = getOrCreateSegmenter(id, call);
@@ -130,7 +130,8 @@ public class SubjectSegmenterProcess implements MethodChannel.MethodCallHandler 
                 }
                resultMap.put("subjects", subjectsData);
             }
-            addImageDimensions(resultMap, call);
+            resultMap.put("width", imageWidth);
+            resultMap.put("height", imageHeight);
 
             result.success(resultMap);
     }
@@ -147,12 +148,6 @@ public class SubjectSegmenterProcess implements MethodChannel.MethodCallHandler 
         }
     }
 
-    private void addImageDimensions(Map<String, Object> map, MethodCall call) {
-        Map<String, Object> imageData = call.argument("imageData");
-        assert imageData != null;
-        map.put("width", imageData.get("width"));
-        map.put("height", imageData.get("height"));
-    }
     private static float[] getConfidences(FloatBuffer floatBuffer) {
         float[] confidences = new float[floatBuffer.remaining()];
         floatBuffer.get(confidences);


### PR DESCRIPTION
@fbernaly 
In the native code, I separated each separately with a method.  e.g. `addForegroundBitmap` and `addConfidenceMask` 
Segmenter options are as follows:  
1. Foreground confidence mask
2. Foreground bitmap
3. Multi-subject confidence mask
4. Multi-subject bitmap 

I used the `Multi-subject confidence mask` in the example app, but any of the options can be enabled. 