### PR TITLE
feat: Add bitmap to input image for text recognition

### DIFF
--- a/packages/example/lib/main.dart
+++ b/packages/example/lib/main.dart
@@ -16,6 +16,7 @@ import 'vision_detector_views/pose_detector_view.dart';
 import 'vision_detector_views/selfie_segmenter_view.dart';
 import 'vision_detector_views/subject_segmenter_view.dart';
 import 'vision_detector_views/text_detector_view.dart';
+import 'vision_detector_views/text_from_widget_view.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -60,6 +61,7 @@ class Home extends StatelessWidget {
                       CustomCard('Image Labeling', ImageLabelView()),
                       CustomCard('Object Detection', ObjectDetectorView()),
                       CustomCard('Text Recognition', TextRecognizerView()),
+                      CustomCard('Text From Widget', TextFromWidgetView()),
                       CustomCard('Digital Ink Recognition', DigitalInkView()),
                       CustomCard('Pose Detection', PoseDetectorView()),
                       CustomCard('Selfie Segmentation', SelfieSegmenterView()),

--- a/packages/example/lib/vision_detector_views/text_from_widget_view.dart
+++ b/packages/example/lib/vision_detector_views/text_from_widget_view.dart
@@ -1,0 +1,153 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+
+class TextFromWidgetView extends StatefulWidget {
+  const TextFromWidgetView({Key? key}) : super(key: key);
+
+  @override
+  State<TextFromWidgetView> createState() => _TextFromWidgetViewState();
+}
+
+class _TextFromWidgetViewState extends State<TextFromWidgetView> {
+  final _textRecognizer = TextRecognizer(script: TextRecognitionScript.latin);
+  final _widgetKey = GlobalKey();
+  String _extractedText = 'Recognized text will appear here';
+  bool _isBusy = false;
+  
+  @override
+  void dispose() {
+    _textRecognizer.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Text From Widget Example'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Center(
+              child: RepaintBoundary(
+                key: _widgetKey,
+                child: Container(
+                  padding: const EdgeInsets.all(16.0),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    border: Border.all(color: Colors.blue, width: 2),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: const Text(
+                    'This is sample text\nthat will be captured\nand processed using\nthe ML Kit Text Recognizer.\n\nTry different fonts\nand styles to test\nthe recognition capabilities!',
+                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: ElevatedButton(
+              onPressed: _isBusy ? null : _extractTextFromWidget,
+              child: const Text('Capture and Recognize Text'),
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Recognition Result:',
+                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+                  ),
+                  const SizedBox(height: 8),
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[200],
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    width: double.infinity,
+                    child: Text(_extractedText),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _extractTextFromWidget() async {
+    if (_isBusy) return;
+    
+    setState(() {
+      _isBusy = true;
+      _extractedText = 'Processing...';
+    });
+
+    try {
+      // Get the RenderObject from the GlobalKey
+      final RenderRepaintBoundary? boundary = 
+          _widgetKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+
+      if (boundary == null) {
+        setState(() {
+          _extractedText = 'Error: Unable to find widget render object';
+          _isBusy = false;
+        });
+        return;
+      }
+
+      // Capture the widget as an image
+      final ui.Image image = await boundary.toImage(pixelRatio: 3.0);
+      
+      // Convert to byte data in raw RGBA format
+      final ByteData? byteData = 
+          await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      
+      if (byteData == null) {
+        setState(() {
+          _extractedText = 'Error: Failed to get image byte data';
+          _isBusy = false;
+        });
+        return;
+      }
+
+      final Uint8List bytes = byteData.buffer.asUint8List();
+      
+      // Create InputImage from bitmap data with dimensions
+      final inputImage = InputImage.fromBitmap(
+        bitmap: bytes,
+        width: image.width,
+        height: image.height,
+      );
+      
+      // Process the image with the text recognizer
+      final RecognizedText recognizedText = 
+          await _textRecognizer.processImage(inputImage);
+      
+      setState(() {
+        _extractedText = recognizedText.text.isNotEmpty 
+            ? recognizedText.text 
+            : 'No text recognized';
+        _isBusy = false;
+      });
+    } catch (e) {
+      setState(() {
+        _extractedText = 'Error processing image: $e';
+        _isBusy = false;
+      });
+    }
+  }
+}

--- a/packages/google_mlkit_commons/CHANGELOG.md
+++ b/packages/google_mlkit_commons/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.10.0
 
-* Add support for bitmap inputs with `InputImage.fromBitmap()` constructor.
+* Add support for bitmap data with `InputImage.fromBitmap()` constructor.
 
 ## 0.9.0
 

--- a/packages/google_mlkit_commons/CHANGELOG.md
+++ b/packages/google_mlkit_commons/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+* Add support for bitmap inputs with `InputImage.fromBitmap()` constructor.
+
 ## 0.9.0
 
 * Update README.

--- a/packages/google_mlkit_commons/android/src/main/java/com/google_mlkit_commons/InputImageConverter.java
+++ b/packages/google_mlkit_commons/android/src/main/java/com/google_mlkit_commons/InputImageConverter.java
@@ -20,10 +20,30 @@ public class InputImageConverter {
     public static InputImage getInputImageFromData(Map<String, Object> imageData,
             Context context,
             MethodChannel.Result result) {
-        //Differentiates whether the image data is a path for a image file or contains image data in form of bytes
+        //Differentiates whether the image data is a path for a image file, contains image data in form of bytes, or a bitmap
         String model = (String) imageData.get("type");
         InputImage inputImage;
-        if (model != null && model.equals("file")) {
+        if (model != null && model.equals("bitmap")) {
+            try {
+                Object bitmapObject = imageData.get("bitmap");
+                if (bitmapObject == null) {
+                    result.error("InputImageConverterError", "Bitmap is null", null);
+                    return null;
+                }
+                android.graphics.Bitmap bitmap = (android.graphics.Bitmap) bitmapObject;
+                int rotation = 0;
+                Object rotationObj = imageData.get("rotation");
+                if (rotationObj != null) {
+                    rotation = (int) rotationObj;
+                }
+                return InputImage.fromBitmap(bitmap, rotation);
+            } catch (Exception e) {
+                Log.e("ImageError", "Getting Bitmap failed");
+                Log.e("ImageError", e.toString());
+                result.error("InputImageConverterError", e.toString(), e);
+                return null;
+            }
+        } else if (model != null && model.equals("file")) {
             try {
                 inputImage = InputImage.fromFilePath(context, Uri.fromFile(new File(((String) imageData.get("path")))));
                 return inputImage;

--- a/packages/google_mlkit_commons/android/src/main/java/com/google_mlkit_commons/InputImageConverter.java
+++ b/packages/google_mlkit_commons/android/src/main/java/com/google_mlkit_commons/InputImageConverter.java
@@ -25,17 +25,26 @@ public class InputImageConverter {
         InputImage inputImage;
         if (model != null && model.equals("bitmap")) {
             try {
-                Object bitmapObject = imageData.get("bitmap");
-                if (bitmapObject == null) {
-                    result.error("InputImageConverterError", "Bitmap is null", null);
+                byte[] bitmapData = (byte[]) imageData.get("bitmapData");
+                if (bitmapData == null) {
+                    result.error("InputImageConverterError", "Bitmap data is null", null);
                     return null;
                 }
-                android.graphics.Bitmap bitmap = (android.graphics.Bitmap) bitmapObject;
+                
+                // Extract the rotation
                 int rotation = 0;
                 Object rotationObj = imageData.get("rotation");
                 if (rotationObj != null) {
                     rotation = (int) rotationObj;
                 }
+                
+                // For Flutter UI bitmap data, we need to decode it into an Android Bitmap
+                android.graphics.Bitmap bitmap = android.graphics.BitmapFactory.decodeByteArray(bitmapData, 0, bitmapData.length);
+                if (bitmap == null) {
+                    result.error("InputImageConverterError", "Failed to decode bitmap from the provided data", null);
+                    return null;
+                }
+                
                 return InputImage.fromBitmap(bitmap, rotation);
             } catch (Exception e) {
                 Log.e("ImageError", "Getting Bitmap failed");

--- a/packages/google_mlkit_commons/ios/Classes/MLKVisionImage+FlutterPlugin.m
+++ b/packages/google_mlkit_commons/ios/Classes/MLKVisionImage+FlutterPlugin.m
@@ -9,6 +9,8 @@
         return [self filePathToVisionImage:imageData[@"path"]];
     } else if ([@"bytes" isEqualToString:imageType]) {
         return [self bytesToVisionImage:imageData];
+    } else if ([@"bitmap" isEqualToString:imageType]) {
+        return [self bitmapToVisionImage:imageData];
     } else {
         NSString *errorReason = [NSString stringWithFormat:@"No image type for: %@", imageType];
         @throw [NSException exceptionWithName:NSInvalidArgumentException
@@ -64,6 +66,32 @@
     CVPixelBufferRelease(pixelBufferRef);
     CGImageRelease(videoImage);
     return [[MLKVisionImage alloc] initWithImage:uiImage];
+}
+
++ (MLKVisionImage *)bitmapToVisionImage:(NSDictionary *)imageData {
+    // In iOS, we receive a FlutterStandardTypedData with the bitmap bytes
+    // Convert it to UIImage
+    FlutterStandardTypedData *bitmapData = imageData[@"bitmap"];
+    
+    if (bitmapData == nil) {
+        NSString *errorReason = @"Bitmap data is nil";
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:errorReason
+                                     userInfo:nil];
+    }
+    
+    NSData *data = bitmapData.data;
+    UIImage *image = [UIImage imageWithData:data];
+    
+    if (image == nil) {
+        NSString *errorReason = @"Failed to create UIImage from bitmap data";
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:errorReason
+                                     userInfo:nil];
+    }
+    
+    MLKVisionImage *visionImage = [[MLKVisionImage alloc] initWithImage:image];
+    return visionImage;
 }
 
 @end

--- a/packages/google_mlkit_commons/ios/Classes/MLKVisionImage+FlutterPlugin.m
+++ b/packages/google_mlkit_commons/ios/Classes/MLKVisionImage+FlutterPlugin.m
@@ -79,7 +79,44 @@
                                      userInfo:nil];
     }
     
-    // Create UIImage from bitmap data
+    // Try to get metadata if available
+    NSDictionary *metadata = imageDict[@"metadata"];
+    if (metadata != nil) {
+        NSNumber *width = metadata[@"width"];
+        NSNumber *height = metadata[@"height"];
+        
+        if (width != nil && height != nil) {
+            // Create bitmap context from raw RGBA data
+            CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+            uint8_t *rawData = (uint8_t*)[bitmapData.data bytes];
+            size_t bytesPerPixel = 4;
+            size_t bytesPerRow = bytesPerPixel * width.intValue;
+            size_t bitsPerComponent = 8;
+            
+            CGContextRef context = CGBitmapContextCreate(rawData, width.intValue, height.intValue,
+                                                 bitsPerComponent, bytesPerRow, colorSpace,
+                                                 kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+            
+            if (context) {
+                CGImageRef imageRef = CGBitmapContextCreateImage(context);
+                UIImage *image = [UIImage imageWithCGImage:imageRef];
+                
+                CGImageRelease(imageRef);
+                CGContextRelease(context);
+                CGColorSpaceRelease(colorSpace);
+                
+                if (image) {
+                    MLKVisionImage *visionImage = [[MLKVisionImage alloc] initWithImage:image];
+                    visionImage.orientation = image.imageOrientation;
+                    return visionImage;
+                }
+            }
+            
+            CGColorSpaceRelease(colorSpace);
+        }
+    }
+    
+    // Fallback: try to create UIImage directly from data
     UIImage *image = [UIImage imageWithData:bitmapData.data];
     
     if (image == nil) {

--- a/packages/google_mlkit_commons/ios/Classes/MLKVisionImage+FlutterPlugin.m
+++ b/packages/google_mlkit_commons/ios/Classes/MLKVisionImage+FlutterPlugin.m
@@ -68,10 +68,9 @@
     return [[MLKVisionImage alloc] initWithImage:uiImage];
 }
 
-+ (MLKVisionImage *)bitmapToVisionImage:(NSDictionary *)imageData {
-    // In iOS, we receive a FlutterStandardTypedData with the bitmap bytes
-    // Convert it to UIImage
-    FlutterStandardTypedData *bitmapData = imageData[@"bitmap"];
++ (MLKVisionImage *)bitmapToVisionImage:(NSDictionary *)imageDict {
+    // Get the bitmap data
+    FlutterStandardTypedData *bitmapData = imageDict[@"bitmapData"];
     
     if (bitmapData == nil) {
         NSString *errorReason = @"Bitmap data is nil";
@@ -80,8 +79,8 @@
                                      userInfo:nil];
     }
     
-    NSData *data = bitmapData.data;
-    UIImage *image = [UIImage imageWithData:data];
+    // Create UIImage from bitmap data
+    UIImage *image = [UIImage imageWithData:bitmapData.data];
     
     if (image == nil) {
         NSString *errorReason = @"Failed to create UIImage from bitmap data";
@@ -91,6 +90,7 @@
     }
     
     MLKVisionImage *visionImage = [[MLKVisionImage alloc] initWithImage:image];
+    visionImage.orientation = image.imageOrientation;
     return visionImage;
 }
 

--- a/packages/google_mlkit_commons/lib/src/input_image.dart
+++ b/packages/google_mlkit_commons/lib/src/input_image.dart
@@ -44,9 +44,25 @@ class InputImage {
   /// Creates an instance of [InputImage] from bitmap data.
   /// 
   /// This constructor is designed to work with bitmap data from Flutter UI components
-  /// such as those obtained from ui.Image.toByteData().
+  /// such as those obtained from ui.Image.toByteData(format: ui.ImageByteFormat.rawRgba).
   /// 
-  /// [bitmap] should be the raw bitmap data.
+  /// Example usage with a RepaintBoundary:
+  /// ```dart
+  /// // Get the RenderObject from a GlobalKey
+  /// final boundary = myKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+  /// // Capture the widget as an image
+  /// final image = await boundary.toImage();
+  /// // Get the raw RGBA bytes
+  /// final byteData = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  /// // Create the InputImage
+  /// final inputImage = InputImage.fromBitmap(
+  ///   bitmap: byteData!.buffer.asUint8List(),
+  ///   width: image.width,
+  ///   height: image.height,
+  /// );
+  /// ```
+  /// 
+  /// [bitmap] should be the raw bitmap data, typically from ui.Image.toByteData().
   /// [width] and [height] are the dimensions of the bitmap.
   /// [rotation] is optional and defaults to 0. It is only used on Android.
   factory InputImage.fromBitmap({

--- a/packages/google_mlkit_commons/lib/src/input_image.dart
+++ b/packages/google_mlkit_commons/lib/src/input_image.dart
@@ -10,13 +10,19 @@ class InputImage {
   /// The bytes of the image.
   final Uint8List? bytes;
 
+  /// The bitmap object for Android.
+  final dynamic bitmap;
+
   /// The type of image.
   final InputImageType type;
 
   /// The image data when creating an image of type = [InputImageType.bytes].
   final InputImageMetadata? metadata;
 
-  InputImage._({this.filePath, this.bytes, required this.type, this.metadata});
+  /// The rotation degrees for bitmap images.
+  final int? rotation;
+
+  InputImage._({this.filePath, this.bytes, this.bitmap, required this.type, this.metadata, this.rotation});
 
   /// Creates an instance of [InputImage] from path of image stored in device.
   factory InputImage.fromFilePath(String path) {
@@ -35,12 +41,25 @@ class InputImage {
         bytes: bytes, type: InputImageType.bytes, metadata: metadata);
   }
 
+  /// Creates an instance of [InputImage] from a bitmap.
+  /// 
+  /// On Android, this will use the native InputImage.fromBitmap().
+  /// On iOS, the bitmap will be converted to a UIImage.
+  /// 
+  /// [rotation] is optional and defaults to 0. It is only used on Android.
+  factory InputImage.fromBitmap({required dynamic bitmap, int rotation = 0}) {
+    return InputImage._(
+        bitmap: bitmap, type: InputImageType.bitmap, rotation: rotation);
+  }
+
   /// Returns a json representation of an instance of [InputImage].
   Map<String, dynamic> toJson() => {
         'bytes': bytes,
         'type': type.name,
         'path': filePath,
-        'metadata': metadata?.toJson()
+        'metadata': metadata?.toJson(),
+        'bitmap': bitmap,
+        'rotation': rotation
       };
 }
 
@@ -48,6 +67,7 @@ class InputImage {
 enum InputImageType {
   file,
   bytes,
+  bitmap,
 }
 
 /// Data of image required when creating image from bytes.

--- a/packages/google_mlkit_commons/lib/src/input_image.dart
+++ b/packages/google_mlkit_commons/lib/src/input_image.dart
@@ -10,8 +10,8 @@ class InputImage {
   /// The bytes of the image.
   final Uint8List? bytes;
 
-  /// The bitmap object for Android.
-  final dynamic bitmap;
+  /// Raw bitmap pixel data.
+  final Uint8List? bitmapData;
 
   /// The type of image.
   final InputImageType type;
@@ -22,7 +22,7 @@ class InputImage {
   /// The rotation degrees for bitmap images.
   final int? rotation;
 
-  InputImage._({this.filePath, this.bytes, this.bitmap, required this.type, this.metadata, this.rotation});
+  InputImage._({this.filePath, this.bytes, this.bitmapData, required this.type, this.metadata, this.rotation});
 
   /// Creates an instance of [InputImage] from path of image stored in device.
   factory InputImage.fromFilePath(String path) {
@@ -41,15 +41,22 @@ class InputImage {
         bytes: bytes, type: InputImageType.bytes, metadata: metadata);
   }
 
-  /// Creates an instance of [InputImage] from a bitmap.
+  /// Creates an instance of [InputImage] from bitmap data.
   /// 
-  /// On Android, this will use the native InputImage.fromBitmap().
-  /// On iOS, the bitmap will be converted to a UIImage.
+  /// This constructor is designed to work with bitmap data from Flutter UI components
+  /// such as those obtained from ui.Image.toByteData().
   /// 
+  /// [bitmap] should be the raw bitmap data.
   /// [rotation] is optional and defaults to 0. It is only used on Android.
-  factory InputImage.fromBitmap({required dynamic bitmap, int rotation = 0}) {
+  factory InputImage.fromBitmap({
+    required Uint8List bitmap,
+    int rotation = 0
+  }) {
     return InputImage._(
-        bitmap: bitmap, type: InputImageType.bitmap, rotation: rotation);
+        bitmapData: bitmap,
+        type: InputImageType.bitmap,
+        rotation: rotation
+    );
   }
 
   /// Returns a json representation of an instance of [InputImage].
@@ -58,7 +65,7 @@ class InputImage {
         'type': type.name,
         'path': filePath,
         'metadata': metadata?.toJson(),
-        'bitmap': bitmap,
+        'bitmapData': bitmapData,
         'rotation': rotation
       };
 }

--- a/packages/google_mlkit_commons/lib/src/input_image.dart
+++ b/packages/google_mlkit_commons/lib/src/input_image.dart
@@ -47,15 +47,27 @@ class InputImage {
   /// such as those obtained from ui.Image.toByteData().
   /// 
   /// [bitmap] should be the raw bitmap data.
+  /// [width] and [height] are the dimensions of the bitmap.
   /// [rotation] is optional and defaults to 0. It is only used on Android.
   factory InputImage.fromBitmap({
     required Uint8List bitmap,
+    required int width,
+    required int height,
     int rotation = 0
   }) {
     return InputImage._(
         bitmapData: bitmap,
         type: InputImageType.bitmap,
-        rotation: rotation
+        rotation: rotation,
+        metadata: InputImageMetadata(
+          size: Size(width.toDouble(), height.toDouble()),
+          rotation: InputImageRotation.values.firstWhere(
+            (element) => element.rawValue == rotation,
+            orElse: () => InputImageRotation.rotation0deg
+          ),
+          format: InputImageFormat.bgra8888, // Assuming BGRA format from Flutter UI
+          bytesPerRow: width * 4, // 4 bytes per pixel (RGBA)
+        )
     );
   }
 

--- a/packages/google_mlkit_commons/pubspec.yaml
+++ b/packages/google_mlkit_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_mlkit_commons
 description: A Flutter plugin with commons files to implement google's standalone ml kit made for mobile platform.
-version: 0.9.0
+version: 0.10.0
 homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_commons
 

--- a/packages/google_mlkit_text_recognition/CHANGELOG.md
+++ b/packages/google_mlkit_text_recognition/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.15.0
 
-* Add support for bitmap inputs with `InputImage.fromBitmap()` constructor.
+* Add support for bitmap data with `InputImage.fromBitmap()` constructor.
 * Update README with bitmap usage example.
 
 ## 0.14.0

--- a/packages/google_mlkit_text_recognition/CHANGELOG.md
+++ b/packages/google_mlkit_text_recognition/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.15.0
+
+* Add support for bitmap inputs with `InputImage.fromBitmap()` constructor.
+* Update README with bitmap usage example.
+
 ## 0.14.0
 
 * Update dependencies.

--- a/packages/google_mlkit_text_recognition/README.md
+++ b/packages/google_mlkit_text_recognition/README.md
@@ -122,7 +122,25 @@ dependencies {
 Create an instance of `InputImage` as explained [here](https://github.com/flutter-ml/google_ml_kit_flutter/blob/master/packages/google_mlkit_commons#creating-an-inputimage).
 
 ```dart
-final InputImage inputImage;
+// From a file
+final InputImage inputImage = InputImage.fromFilePath(filePath);
+
+// From bytes
+final InputImage inputImage = InputImage.fromBytes(
+  bytes: bytes,
+  metadata: InputImageMetadata(
+    size: Size(width, height),
+    rotation: InputImageRotation.rotation0deg,
+    format: InputImageFormat.nv21, // or other formats
+    bytesPerRow: bytesPerRow,
+  ),
+);
+
+// From a bitmap (supports both Android and iOS)
+final InputImage inputImage = InputImage.fromBitmap(
+  bitmap: bitmap, // Platform-specific bitmap object
+  rotation: 0, // optional, defaults to 0
+);
 ```
 
 #### Create an instance of `TextRecognizer`

--- a/packages/google_mlkit_text_recognition/README.md
+++ b/packages/google_mlkit_text_recognition/README.md
@@ -137,8 +137,12 @@ final InputImage inputImage = InputImage.fromBytes(
 );
 
 // From bitmap data
+final ui.Image image = await recorder.endRecording().toImage(width, height);
+final ByteData? byteData = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
 final InputImage inputImage = InputImage.fromBitmap(
-  bitmap: uiImageBytes, // Uint8List from ui.Image.toByteData() for example
+  bitmap: byteData!.buffer.asUint8List(),
+  width: width,
+  height: height,
   rotation: 0, // optional, defaults to 0, only used on Android
 );
 ```

--- a/packages/google_mlkit_text_recognition/README.md
+++ b/packages/google_mlkit_text_recognition/README.md
@@ -136,10 +136,10 @@ final InputImage inputImage = InputImage.fromBytes(
   ),
 );
 
-// From a bitmap (supports both Android and iOS)
+// From bitmap data
 final InputImage inputImage = InputImage.fromBitmap(
-  bitmap: bitmap, // Platform-specific bitmap object
-  rotation: 0, // optional, defaults to 0
+  bitmap: uiImageBytes, // Uint8List from ui.Image.toByteData() for example
+  rotation: 0, // optional, defaults to 0, only used on Android
 );
 ```
 

--- a/packages/google_mlkit_text_recognition/pubspec.yaml
+++ b/packages/google_mlkit_text_recognition/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_mlkit_text_recognition
 description: A Flutter plugin to use Google's ML Kit Text Recognition to recognize text in any Chinese, Devanagari, Japanese, Korean and Latin character set.
-version: 0.14.0
+version: 0.15.0
 homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_text_recognition
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mlkit_commons: ^0.9.0
+  google_mlkit_commons: ^0.10.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Closes #753.

In this PR I am adding the capability to extract text from a bitmap. This was mentioned in the Android ML Kit docs, but not in the iOS ones.

I have tested this in both Android and iOS and supplied an example case too.

This is important to me because I am using the `camera` package, but I am manipulating the image and I want to recognise text in only a portion of the image, so in order to make this I am capturing the bitmap image from the widget and cropping it, before sending it to the text recogniser.

This simplifies also how we deal with images from the camera, as there are compatibility issues with the camera image formats for Android and iOS, with many open issues, so this can be used as a workaround.