### PR TITLE
feat: SPM migration for all packages + support simulator

### DIFF
--- a/packages/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/example/ios/Runner.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
-					"-all_load",
+					
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -480,7 +480,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
-					"-all_load",
+					
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -507,7 +507,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
-					"-all_load",
+					
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/packages/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,9 +3,10 @@
     {
       "identity" : "google-mlkit-swiftpm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/arrrrny/google-mlkit-swiftpm",
+      "location" : "https://github.com/mdata-group/google-mlkit-swiftpm",
       "state" : {
-        "revision" : "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+        "revision" : "9f25322b887502499c80a7f083de14aea55d34ef",
+        "version" : "9.0.0-simfix2"
       }
     },
     {

--- a/packages/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,9 +3,10 @@
     {
       "identity" : "google-mlkit-swiftpm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/arrrrny/google-mlkit-swiftpm",
+      "location" : "https://github.com/mdata-group/google-mlkit-swiftpm",
       "state" : {
-        "revision" : "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+        "revision" : "9f25322b887502499c80a7f083de14aea55d34ef",
+        "version" : "9.0.0-simfix2"
       }
     },
     {

--- a/packages/google_mlkit_barcode_scanning/ios/google_mlkit_barcode_scanning/Package.swift
+++ b/packages/google_mlkit_barcode_scanning/ios/google_mlkit_barcode_scanning/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_barcode_scanning/pubspec.yaml
+++ b/packages/google_mlkit_barcode_scanning/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitBarcodeScanningPlugin
       ios:
         pluginClass: GoogleMlKitBarcodeScanningPlugin
+        swiftPackage:
+          path: ios/google_mlkit_barcode_scanning

--- a/packages/google_mlkit_commons/ios/google_mlkit_commons/Package.resolved
+++ b/packages/google_mlkit_commons/ios/google_mlkit_commons/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "google-mlkit-swiftpm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/arrrrny/google-mlkit-swiftpm",
+      "location" : "https://github.com/mdata-group/google-mlkit-swiftpm",
       "state" : {
-        "revision" : "83e2f4e1ea4ce0986979ee7b2bbbfa7bd9ddf576",
-        "version" : "9.0.0-textfix5"
+        "revision" : "9f25322b887502499c80a7f083de14aea55d34ef",
+        "version" : "9.0.0-simfix2"
       }
     },
     {

--- a/packages/google_mlkit_commons/ios/google_mlkit_commons/Package.swift
+++ b/packages/google_mlkit_commons/ios/google_mlkit_commons/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_commons/pubspec.yaml
+++ b/packages/google_mlkit_commons/pubspec.yaml
@@ -25,3 +25,5 @@ flutter:
         pluginClass: GoogleMlKitCommonsPlugin
       ios:
         pluginClass: GoogleMlKitCommonsPlugin
+        swiftPackage:
+          path: ios/google_mlkit_commons

--- a/packages/google_mlkit_digital_ink_recognition/ios/google_mlkit_digital_ink_recognition/Package.resolved
+++ b/packages/google_mlkit_digital_ink_recognition/ios/google_mlkit_digital_ink_recognition/Package.resolved
@@ -3,9 +3,9 @@
     {
       "identity" : "google-mlkit-swiftpm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/arrrrny/google-mlkit-swiftpm",
+      "location" : "https://github.com/mdata-group/google-mlkit-swiftpm",
       "state" : {
-        "revision" : "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+        "revision" : "9f25322b887502499c80a7f083de14aea55d34ef"
       }
     },
     {

--- a/packages/google_mlkit_digital_ink_recognition/pubspec.yaml
+++ b/packages/google_mlkit_digital_ink_recognition/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitDigitalInkRecognitionPlugin
       ios:
         pluginClass: GoogleMlKitDigitalInkRecognitionPlugin
+        swiftPackage:
+          path: ios/google_mlkit_digital_ink_recognition

--- a/packages/google_mlkit_document_scanner/pubspec.yaml
+++ b/packages/google_mlkit_document_scanner/pubspec.yaml
@@ -25,3 +25,5 @@ flutter:
         pluginClass: GoogleMlKitDocumentScannerPlugin
       ios:
         pluginClass: GoogleMlKitDocumentScannerPlugin
+        swiftPackage:
+          path: ios/google_mlkit_document_scanner

--- a/packages/google_mlkit_entity_extraction/ios/google_mlkit_entity_extraction/Package.resolved
+++ b/packages/google_mlkit_entity_extraction/ios/google_mlkit_entity_extraction/Package.resolved
@@ -3,9 +3,9 @@
     {
       "identity" : "google-mlkit-swiftpm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/arrrrny/google-mlkit-swiftpm",
+      "location" : "https://github.com/mdata-group/google-mlkit-swiftpm",
       "state" : {
-        "revision" : "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+        "revision" : "9f25322b887502499c80a7f083de14aea55d34ef"
       }
     },
     {

--- a/packages/google_mlkit_entity_extraction/pubspec.yaml
+++ b/packages/google_mlkit_entity_extraction/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitEntityExtractionPlugin
       ios:
         pluginClass: GoogleMlKitEntityExtractionPlugin
+        swiftPackage:
+          path: ios/google_mlkit_entity_extraction

--- a/packages/google_mlkit_face_detection/ios/google_mlkit_face_detection/Package.swift
+++ b/packages/google_mlkit_face_detection/ios/google_mlkit_face_detection/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_face_detection/pubspec.yaml
+++ b/packages/google_mlkit_face_detection/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitFaceDetectionPlugin
       ios:
         pluginClass: GoogleMlKitFaceDetectionPlugin
+        swiftPackage:
+          path: ios/google_mlkit_face_detection

--- a/packages/google_mlkit_face_mesh_detection/ios/google_mlkit_face_mesh_detection/Package.resolved
+++ b/packages/google_mlkit_face_mesh_detection/ios/google_mlkit_face_mesh_detection/Package.resolved
@@ -3,9 +3,9 @@
     {
       "identity" : "google-mlkit-swiftpm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/arrrrny/google-mlkit-swiftpm",
+      "location" : "https://github.com/mdata-group/google-mlkit-swiftpm",
       "state" : {
-        "revision" : "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+        "revision" : "9f25322b887502499c80a7f083de14aea55d34ef"
       }
     },
     {

--- a/packages/google_mlkit_face_mesh_detection/pubspec.yaml
+++ b/packages/google_mlkit_face_mesh_detection/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitFaceMeshDetectionPlugin
       ios:
         pluginClass: GoogleMlKitFaceMeshDetectionPlugin
+        swiftPackage:
+          path: ios/google_mlkit_face_mesh_detection

--- a/packages/google_mlkit_genai_image_description/pubspec.yaml
+++ b/packages/google_mlkit_genai_image_description/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitGenaiImageDescriptionPlugin
       ios:
         pluginClass: GoogleMlKitGenaiImageDescriptionPlugin
+        swiftPackage:
+          path: ios/google_mlkit_genai_image_description

--- a/packages/google_mlkit_genai_prompt/ios/google_mlkit_genai_prompt/Package.swift
+++ b/packages/google_mlkit_genai_prompt/ios/google_mlkit_genai_prompt/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["google_mlkit_genai_prompt"])
     ],
     dependencies: [
-
+        
     ],
     targets: [
         .target(

--- a/packages/google_mlkit_genai_prompt/pubspec.yaml
+++ b/packages/google_mlkit_genai_prompt/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitGenaiPromptPlugin
       ios:
         pluginClass: GoogleMlKitGenaiPromptPlugin
+        swiftPackage:
+          path: ios/google_mlkit_genai_prompt

--- a/packages/google_mlkit_genai_proofreading/ios/google_mlkit_genai_proofreading/Package.swift
+++ b/packages/google_mlkit_genai_proofreading/ios/google_mlkit_genai_proofreading/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["google_mlkit_genai_proofreading"])
     ],
     dependencies: [
-
+        
     ],
     targets: [
         .target(

--- a/packages/google_mlkit_genai_proofreading/pubspec.yaml
+++ b/packages/google_mlkit_genai_proofreading/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitGenaiProofreadingPlugin
       ios:
         pluginClass: GoogleMlKitGenaiProofreadingPlugin
+        swiftPackage:
+          path: ios/google_mlkit_genai_proofreading

--- a/packages/google_mlkit_genai_rewriting/pubspec.yaml
+++ b/packages/google_mlkit_genai_rewriting/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitGenaiRewritingPlugin
       ios:
         pluginClass: GoogleMlKitGenaiRewritingPlugin
+        swiftPackage:
+          path: ios/google_mlkit_genai_rewriting

--- a/packages/google_mlkit_genai_speech_recognition/ios/google_mlkit_genai_speech_recognition/Package.swift
+++ b/packages/google_mlkit_genai_speech_recognition/ios/google_mlkit_genai_speech_recognition/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["google_mlkit_genai_speech_recognition"])
     ],
     dependencies: [
-
+        
     ],
     targets: [
         .target(

--- a/packages/google_mlkit_genai_speech_recognition/pubspec.yaml
+++ b/packages/google_mlkit_genai_speech_recognition/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitGenaiSpeechRecognitionPlugin
       ios:
         pluginClass: GoogleMlKitGenaiSpeechRecognitionPlugin
+        swiftPackage:
+          path: ios/google_mlkit_genai_speech_recognition

--- a/packages/google_mlkit_genai_summarization/ios/google_mlkit_genai_summarization/Package.swift
+++ b/packages/google_mlkit_genai_summarization/ios/google_mlkit_genai_summarization/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["google_mlkit_genai_summarization"])
     ],
     dependencies: [
-
+        
     ],
     targets: [
         .target(

--- a/packages/google_mlkit_genai_summarization/pubspec.yaml
+++ b/packages/google_mlkit_genai_summarization/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitGenaiSummarizationPlugin
       ios:
         pluginClass: GoogleMlKitGenaiSummarizationPlugin
+        swiftPackage:
+          path: ios/google_mlkit_genai_summarization

--- a/packages/google_mlkit_image_labeling/ios/google_mlkit_image_labeling/Package.swift
+++ b/packages/google_mlkit_image_labeling/ios/google_mlkit_image_labeling/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_image_labeling/pubspec.yaml
+++ b/packages/google_mlkit_image_labeling/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitImageLabelingPlugin
       ios:
         pluginClass: GoogleMlKitImageLabelingPlugin
+        swiftPackage:
+          path: ios/google_mlkit_image_labeling

--- a/packages/google_mlkit_language_id/ios/google_mlkit_language_id/Package.swift
+++ b/packages/google_mlkit_language_id/ios/google_mlkit_language_id/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_language_id/pubspec.yaml
+++ b/packages/google_mlkit_language_id/pubspec.yaml
@@ -25,3 +25,5 @@ flutter:
         pluginClass: GoogleMlKitLanguageIdPlugin
       ios:
         pluginClass: GoogleMlKitLanguageIdPlugin
+        swiftPackage:
+          path: ios/google_mlkit_language_id

--- a/packages/google_mlkit_object_detection/ios/google_mlkit_object_detection/Package.swift
+++ b/packages/google_mlkit_object_detection/ios/google_mlkit_object_detection/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_object_detection/pubspec.yaml
+++ b/packages/google_mlkit_object_detection/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitObjectDetectionPlugin
       ios:
         pluginClass: GoogleMlKitObjectDetectionPlugin
+        swiftPackage:
+          path: ios/google_mlkit_object_detection

--- a/packages/google_mlkit_pose_detection/ios/google_mlkit_pose_detection/Package.swift
+++ b/packages/google_mlkit_pose_detection/ios/google_mlkit_pose_detection/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_pose_detection/pubspec.yaml
+++ b/packages/google_mlkit_pose_detection/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitPoseDetectionPlugin
       ios:
         pluginClass: GoogleMlKitPoseDetectionPlugin
+        swiftPackage:
+          path: ios/google_mlkit_pose_detection

--- a/packages/google_mlkit_selfie_segmentation/ios/google_mlkit_selfie_segmentation/Package.swift
+++ b/packages/google_mlkit_selfie_segmentation/ios/google_mlkit_selfie_segmentation/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_selfie_segmentation/pubspec.yaml
+++ b/packages/google_mlkit_selfie_segmentation/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitSelfieSegmentationPlugin
       ios:
         pluginClass: GoogleMlKitSelfieSegmentationPlugin
+        swiftPackage:
+          path: ios/google_mlkit_selfie_segmentation

--- a/packages/google_mlkit_smart_reply/ios/google_mlkit_smart_reply/Package.swift
+++ b/packages/google_mlkit_smart_reply/ios/google_mlkit_smart_reply/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_smart_reply/pubspec.yaml
+++ b/packages/google_mlkit_smart_reply/pubspec.yaml
@@ -25,3 +25,5 @@ flutter:
         pluginClass: GoogleMlKitSmartReplyPlugin
       ios:
         pluginClass: GoogleMlKitSmartReplyPlugin
+        swiftPackage:
+          path: ios/google_mlkit_smart_reply

--- a/packages/google_mlkit_subject_segmentation/ios/google_mlkit_subject_segmentation/Package.swift
+++ b/packages/google_mlkit_subject_segmentation/ios/google_mlkit_subject_segmentation/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["google_mlkit_subject_segmentation"])
     ],
     dependencies: [
-
+        
     ],
     targets: [
         .target(

--- a/packages/google_mlkit_subject_segmentation/pubspec.yaml
+++ b/packages/google_mlkit_subject_segmentation/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitSubjectSegmentationPlugin
       ios:
         pluginClass: GoogleMlKitSubjectSegmentationPlugin
+        swiftPackage:
+          path: ios/google_mlkit_subject_segmentation

--- a/packages/google_mlkit_text_recognition/ios/google_mlkit_text_recognition/Package.swift
+++ b/packages/google_mlkit_text_recognition/ios/google_mlkit_text_recognition/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_text_recognition/pubspec.yaml
+++ b/packages/google_mlkit_text_recognition/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitTextRecognitionPlugin
       ios:
         pluginClass: GoogleMlKitTextRecognitionPlugin
+        swiftPackage:
+          path: ios/google_mlkit_text_recognition

--- a/packages/google_mlkit_translation/ios/google_mlkit_translation/Package.swift
+++ b/packages/google_mlkit_translation/ios/google_mlkit_translation/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         .package(path: "../../../google_mlkit_commons/ios/google_mlkit_commons"),
         .package(
-            url: "https://github.com/arrrrny/google-mlkit-swiftpm",
-            revision: "617e67690b277b7d2063c2e4f367bd0155ee79c0"
+            url: "https://github.com/mdata-group/google-mlkit-swiftpm",
+            exact: "9.0.0-simfix2"
         )
     ],
     targets: [

--- a/packages/google_mlkit_translation/pubspec.yaml
+++ b/packages/google_mlkit_translation/pubspec.yaml
@@ -26,3 +26,5 @@ flutter:
         pluginClass: GoogleMlKitTranslationPlugin
       ios:
         pluginClass: GoogleMlKitTranslationPlugin
+        swiftPackage:
+          path: ios/google_mlkit_translation


### PR DESCRIPTION
@fbernaly I found that fork https://github.com/mdata-group/google-mlkit-swiftpm fix simulator problem, but some things linked twice results to Error (Xcode): 115 duplicate symbols

There are 115 duplicate symbols because MLKitCommon gets linked multiple times. `google_mlkit_commons` depends on `MLKitBarcodeScanning` (which includes `MLKitCommon`), and other packages like `barcode_scanning` also depend on `MLKitBarcodeScanning` directly — causing `MLKitCommon` to be linked twice.

`
duplicate symbol 'MLKITx_strings::CleanStringLineEndings(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, bool)' in:
duplicate symbol 'MLKITx_strings::ShellEscape(MLKITx_absl::string_view)' in:
duplicate symbol 'MLKITx_strings::EightBase32DigitsToFiveBytes(char const*, unsigned char*)' in:
duplicate symbol 'MLKITx_absl::WebSafeBase64Unescape(char const*, long, char*, long)' in:
duplicate symbol 'MLKITx_strings::ByteStringToAscii(MLKITx_absl::string_view, long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*)' in:
duplicate symbol 'MLKITx_absl::base_internal::delete_hooks_' in:
duplicate symbol 'MLKITx_absl::base_internal::MallocHook::AddNewHook(void (*)(MLKITx_tcmalloc::MallocHook::NewInfo const&))' in:
duplicate symbol 'MLKITx_absl::base_internal::MallocHook::AddMremapHook(void (*)(void const*, void const*, unsigned long, unsigned long, int, void const*))' in:
duplicate symbol 'MLKITx_strings::TenHexDigitsToEightBas…
`

Could you check it? Maybe you can fix it