### PR TITLE
chore(android): migrate plugins to built-in Kotlin

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-java@v5.6.0
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - uses: subosito/flutter-action@v2.23.0
         with:
-          flutter-version: '3.35.3'
+          flutter-version: '3.44.8'
           cache: true
 
       - name: Install dependencies for google_ml_kit
@@ -140,3 +140,61 @@ jobs:
         run: brew install swiftlint
       - name: Run SwiftLint on Swift code
         run: swiftlint lint
+
+  build-android:
+    name: Build Android example without plugin KGP warnings
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-java@v5.6.0
+        with:
+          java-version: 17
+          distribution: temurin
+      - uses: subosito/flutter-action@v2.23.0
+        with:
+          flutter-version: '3.44.8'
+          cache: true
+      - name: Install dependencies
+        working-directory: ./packages/example
+        run: flutter pub get
+      - name: Build Android example
+        working-directory: ./packages/example
+        shell: bash
+        run: |
+          set -o pipefail
+          flutter build apk --debug 2>&1 | tee android-build.log
+          ! grep -F "plugins that apply Kotlin Gradle Plugin" android-build.log
+
+  # Flutter only supports enabling AGP 9's built-in Kotlin from 3.47 onward.
+  # Keep this beta lane until 3.47 is stable, then pin the stable release.
+  build-android-built-in-kotlin:
+    name: Build Android example with AGP 9 built-in Kotlin
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-java@v5.6.0
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: subosito/flutter-action@v2.23.0
+        with:
+          flutter-version: '3.47.0-0.2.pre'
+          channel: beta
+          cache: true
+      - name: Enable AGP 9 built-in Kotlin
+        working-directory: ./packages/example
+        shell: bash
+        run: |
+          perl -pi -e 's/version "8\.13\.0"/version "9.3.1"/' android/settings.gradle.kts
+          perl -pi -e 's/gradle-8\.14\.3-all\.zip/gradle-9.6.1-all.zip/' android/gradle/wrapper/gradle-wrapper.properties
+          perl -pi -e 's/android\.builtInKotlin=false/android.builtInKotlin=true/' android/gradle.properties
+      - name: Install dependencies
+        working-directory: ./packages/example
+        run: flutter pub get
+      - name: Build Android example
+        working-directory: ./packages/example
+        shell: bash
+        run: |
+          set -o pipefail
+          flutter build apk --debug 2>&1 | tee android-build.log
+          ! grep -E 'plugins that apply Kotlin Gradle Plugin|applies the Kotlin Gradle Plugin|KGP\) was unsuccessful' android-build.log

--- a/packages/example/android/app/build.gradle.kts
+++ b/packages/example/android/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id("dev.flutter.flutter-gradle-plugin")
 }
 
@@ -12,10 +11,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     defaultConfig {
@@ -34,6 +29,12 @@ android {
 
     aaptOptions {
         noCompress("tflite") // Your model's file extension: "tflite", "lite", etc.
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 

--- a/packages/example/android/gradle.properties
+++ b/packages/example/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
+android.newDsl=false
+android.builtInKotlin=false

--- a/packages/example/lib/activity_indicator/activity_indicator.dart
+++ b/packages/example/lib/activity_indicator/activity_indicator.dart
@@ -3,17 +3,21 @@
 import 'package:flutter/material.dart';
 
 class Toast {
-  void show(String message, Future<String> t, BuildContext context,
-      State<StatefulWidget> state) async {
+  void show(
+    String message,
+    Future<String> t,
+    BuildContext context,
+    State<StatefulWidget> state,
+  ) async {
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
     showLoadingIndicator(context, message);
     final verificationResult = await t;
     Navigator.of(context).pop();
     if (!state.mounted) return;
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      content: Text('Result: ${verificationResult.toString()}'),
-    ));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Result: ${verificationResult.toString()}')),
+    );
   }
 
   void showLoadingIndicator(BuildContext context, String text) {
@@ -22,13 +26,15 @@ class Toast {
       barrierDismissible: false,
       builder: (BuildContext context) {
         return PopScope(
-            canPop: false,
-            child: AlertDialog(
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.all(Radius.circular(8.0))),
-              backgroundColor: Colors.black87,
-              content: LoadingIndicator(text: text),
-            ));
+          canPop: false,
+          child: AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(8.0)),
+            ),
+            backgroundColor: Colors.black87,
+            content: LoadingIndicator(text: text),
+          ),
+        );
       },
     );
   }
@@ -42,31 +48,36 @@ class LoadingIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-        padding: EdgeInsets.all(16),
-        color: Colors.black.withAlpha(204),
-        child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            mainAxisSize: MainAxisSize.min,
-            children: [_getLoadingIndicator(), _getHeading(), _getText(text)]));
+      padding: EdgeInsets.all(16),
+      color: Colors.black.withAlpha(204),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [_getLoadingIndicator(), _getHeading(), _getText(text)],
+      ),
+    );
   }
 
   Widget _getLoadingIndicator() {
     return Padding(
-        padding: EdgeInsets.only(bottom: 16),
-        child: SizedBox(
-            width: 32,
-            height: 32,
-            child: CircularProgressIndicator(strokeWidth: 3)));
+      padding: EdgeInsets.only(bottom: 16),
+      child: SizedBox(
+        width: 32,
+        height: 32,
+        child: CircularProgressIndicator(strokeWidth: 3),
+      ),
+    );
   }
 
   Widget _getHeading() {
     return Padding(
-        padding: EdgeInsets.only(bottom: 4),
-        child: Text(
-          'Please wait …',
-          style: TextStyle(color: Colors.white, fontSize: 16),
-          textAlign: TextAlign.center,
-        ));
+      padding: EdgeInsets.only(bottom: 4),
+      child: Text(
+        'Please wait …',
+        style: TextStyle(color: Colors.white, fontSize: 16),
+        textAlign: TextAlign.center,
+      ),
+    );
   }
 
   Widget _getText(String displayedText) {

--- a/packages/example/lib/main.dart
+++ b/packages/example/lib/main.dart
@@ -27,10 +27,7 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: Home(),
-    );
+    return MaterialApp(debugShowCheckedModeBanner: false, home: Home());
   }
 }
 
@@ -57,7 +54,9 @@ class Home extends StatelessWidget {
                       CustomCard('Face Detection', FaceDetectorView()),
                       if (Platform.isAndroid)
                         CustomCard(
-                            'Face Mesh Detection', FaceMeshDetectorView()),
+                          'Face Mesh Detection',
+                          FaceMeshDetectorView(),
+                        ),
                       CustomCard('Image Labeling', ImageLabelView()),
                       CustomCard('Object Detection', ObjectDetectorView()),
                       CustomCard('Text Recognition', TextRecognizerView()),
@@ -69,39 +68,49 @@ class Home extends StatelessWidget {
                         CustomCard('Document Scanner', DocumentScannerView()),
                       if (Platform.isAndroid)
                         CustomCard(
-                            'Subject Segmentation', SubjectSegmenterView())
+                          'Subject Segmentation',
+                          SubjectSegmenterView(),
+                        ),
                     ],
                   ),
-                  SizedBox(
-                    height: 20,
-                  ),
+                  SizedBox(height: 20),
                   ExpansionTile(
                     title: const Text('Natural Language APIs'),
                     children: [
                       CustomCard('Language ID', LanguageIdentifierView()),
                       CustomCard(
-                          'On-device Translation', LanguageTranslatorView()),
+                        'On-device Translation',
+                        LanguageTranslatorView(),
+                      ),
                       CustomCard('Smart Reply', SmartReplyView()),
                       CustomCard('Entity Extraction', EntityExtractionView()),
                     ],
                   ),
-                  SizedBox(
-                    height: 20,
-                  ),
+                  SizedBox(height: 20),
                   if (Platform.isAndroid)
                     ExpansionTile(
                       title: const Text('GenAI APIs'),
                       children: [
-                        CustomCard('Summarization',
-                            _GenAIPlaceholderView('Summarization')),
-                        CustomCard('Proofreading',
-                            _GenAIPlaceholderView('Proofreading')),
                         CustomCard(
-                            'Rewriting', _GenAIPlaceholderView('Rewriting')),
-                        CustomCard('Image Description',
-                            _GenAIPlaceholderView('Image Description')),
-                        CustomCard('Speech Recognition',
-                            _GenAIPlaceholderView('Speech Recognition')),
+                          'Summarization',
+                          _GenAIPlaceholderView('Summarization'),
+                        ),
+                        CustomCard(
+                          'Proofreading',
+                          _GenAIPlaceholderView('Proofreading'),
+                        ),
+                        CustomCard(
+                          'Rewriting',
+                          _GenAIPlaceholderView('Rewriting'),
+                        ),
+                        CustomCard(
+                          'Image Description',
+                          _GenAIPlaceholderView('Image Description'),
+                        ),
+                        CustomCard(
+                          'Speech Recognition',
+                          _GenAIPlaceholderView('Speech Recognition'),
+                        ),
                         CustomCard('Prompt', _GenAIPlaceholderView('Prompt')),
                       ],
                     ),
@@ -123,20 +132,14 @@ class _GenAIPlaceholderView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text('$featureName (GenAI)'),
-      ),
+      appBar: AppBar(title: Text('$featureName (GenAI)')),
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(
-                Icons.info_outline,
-                size: 64,
-                color: Colors.blue,
-              ),
+              Icon(Icons.info_outline, size: 64, color: Colors.blue),
               SizedBox(height: 16),
               Text(
                 '$featureName API',
@@ -152,9 +155,9 @@ class _GenAIPlaceholderView extends StatelessWidget {
               Text(
                 'Implementation coming soon.',
                 textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      fontStyle: FontStyle.italic,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic),
               ),
             ],
           ),
@@ -184,12 +187,18 @@ class CustomCard extends StatelessWidget {
         ),
         onTap: () {
           if (!featureCompleted) {
-            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                content:
-                    const Text('This feature has not been implemented yet')));
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: const Text(
+                  'This feature has not been implemented yet',
+                ),
+              ),
+            );
           } else {
             Navigator.push(
-                context, MaterialPageRoute(builder: (context) => _viewPage));
+              context,
+              MaterialPageRoute(builder: (context) => _viewPage),
+            );
           }
         },
       ),

--- a/packages/example/lib/nlp_detector_views/entity_extraction_view.dart
+++ b/packages/example/lib/nlp_detector_views/entity_extraction_view.dart
@@ -11,8 +11,9 @@ class EntityExtractionView extends StatefulWidget {
 class _EntityExtractionViewState extends State<EntityExtractionView> {
   final _controller = TextEditingController();
   final _modelManager = EntityExtractorModelManager();
-  final _entityExtractor =
-      EntityExtractor(language: EntityExtractorLanguage.english);
+  final _entityExtractor = EntityExtractor(
+    language: EntityExtractorLanguage.english,
+  );
   var _entities = <EntityAnnotation>[];
   final _language = EntityExtractorLanguage.english;
 
@@ -26,9 +27,7 @@ class _EntityExtractionViewState extends State<EntityExtractionView> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Entity Extractor'),
-        ),
+        appBar: AppBar(title: const Text('Entity Extractor')),
         body: GestureDetector(
           onTap: () {
             FocusScope.of(context).unfocus();
@@ -36,18 +35,13 @@ class _EntityExtractionViewState extends State<EntityExtractionView> {
           child: SingleChildScrollView(
             child: Column(
               children: [
-                const SizedBox(
-                  height: 20,
-                ),
+                const SizedBox(height: 20),
                 const Center(child: Text('Enter text (English)')),
                 Padding(
                   padding: const EdgeInsets.all(20.0),
                   child: Container(
                     padding: EdgeInsets.symmetric(horizontal: 20),
-                    decoration: BoxDecoration(
-                        border: Border.all(
-                      width: 2,
-                    )),
+                    decoration: BoxDecoration(border: Border.all(width: 2)),
                     child: TextField(
                       controller: _controller,
                       decoration: InputDecoration(border: InputBorder.none),
@@ -55,33 +49,40 @@ class _EntityExtractionViewState extends State<EntityExtractionView> {
                     ),
                   ),
                 ),
-                Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                  ElevatedButton(
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    ElevatedButton(
                       onPressed: _extractEntities,
-                      child: Text('Extract Entities'))
-                ]),
+                      child: Text('Extract Entities'),
+                    ),
+                  ],
+                ),
                 const SizedBox(height: 20),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: [
                     ElevatedButton(
-                        onPressed: _downloadModel,
-                        child: Text('Download Model')),
+                      onPressed: _downloadModel,
+                      child: Text('Download Model'),
+                    ),
                     ElevatedButton(
-                        onPressed: _deleteModel, child: Text('Delete Model')),
+                      onPressed: _deleteModel,
+                      child: Text('Delete Model'),
+                    ),
                   ],
                 ),
                 SizedBox(height: 20),
                 Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceAround,
-                    children: [
-                      ElevatedButton(
-                          onPressed: _isModelDownloaded,
-                          child: Text('Check download'))
-                    ]),
-                const SizedBox(
-                  height: 30,
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    ElevatedButton(
+                      onPressed: _isModelDownloaded,
+                      child: Text('Check download'),
+                    ),
+                  ],
                 ),
+                const SizedBox(height: 30),
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 30),
                   child: const Text('Result', style: TextStyle(fontSize: 20)),
@@ -92,11 +93,11 @@ class _EntityExtractionViewState extends State<EntityExtractionView> {
                   physics: NeverScrollableScrollPhysics(),
                   itemCount: _entities.length,
                   itemBuilder: (context, index) => ExpansionTile(
-                      title: Text(_entities[index].text),
-                      children: _entities[index]
-                          .entities
-                          .map((e) => Text(e.toString()))
-                          .toList()),
+                    title: Text(_entities[index].text),
+                    children: _entities[index].entities
+                        .map((e) => Text(e.toString()))
+                        .toList(),
+                  ),
                 ),
               ],
             ),
@@ -108,32 +109,35 @@ class _EntityExtractionViewState extends State<EntityExtractionView> {
 
   Future<void> _downloadModel() async {
     Toast().show(
-        'Downloading model...',
-        _modelManager
-            .downloadModel(_language.name)
-            .then((value) => value ? 'success' : 'failed'),
-        context,
-        this);
+      'Downloading model...',
+      _modelManager
+          .downloadModel(_language.name)
+          .then((value) => value ? 'success' : 'failed'),
+      context,
+      this,
+    );
   }
 
   Future<void> _deleteModel() async {
     Toast().show(
-        'Deleting model...',
-        _modelManager
-            .deleteModel(_language.name)
-            .then((value) => value ? 'success' : 'failed'),
-        context,
-        this);
+      'Deleting model...',
+      _modelManager
+          .deleteModel(_language.name)
+          .then((value) => value ? 'success' : 'failed'),
+      context,
+      this,
+    );
   }
 
   Future<void> _isModelDownloaded() async {
     Toast().show(
-        'Checking if model is downloaded...',
-        _modelManager
-            .isModelDownloaded(_language.name)
-            .then((value) => value ? 'downloaded' : 'not downloaded'),
-        context,
-        this);
+      'Checking if model is downloaded...',
+      _modelManager
+          .isModelDownloaded(_language.name)
+          .then((value) => value ? 'downloaded' : 'not downloaded'),
+      context,
+      this,
+    );
   }
 
   Future<void> _extractEntities() async {

--- a/packages/example/lib/nlp_detector_views/language_identifier_view.dart
+++ b/packages/example/lib/nlp_detector_views/language_identifier_view.dart
@@ -23,40 +23,45 @@ class _LanguageIdentifierViewState extends State<LanguageIdentifierView> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('Language Identification')),
-      body: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-        Padding(
-          padding: const EdgeInsets.all(15.0),
-          child: TextField(
-            controller: _controller,
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(15.0),
+            child: TextField(controller: _controller),
           ),
-        ),
-        SizedBox(height: 15),
-        _identifiedLanguage == ''
-            ? Container()
-            : Container(
-                margin: EdgeInsets.only(bottom: 5),
-                child: Text(
-                  'Identified Language: $_identifiedLanguage',
-                  style: TextStyle(fontSize: 20),
-                )),
-        ElevatedButton(
+          SizedBox(height: 15),
+          _identifiedLanguage == ''
+              ? Container()
+              : Container(
+                  margin: EdgeInsets.only(bottom: 5),
+                  child: Text(
+                    'Identified Language: $_identifiedLanguage',
+                    style: TextStyle(fontSize: 20),
+                  ),
+                ),
+          ElevatedButton(
             onPressed: _identifyLanguage,
-            child: const Text('Identify Language')),
-        SizedBox(height: 15),
-        ElevatedButton(
-          onPressed: _identifyPossibleLanguages,
-          child: const Text('Identify possible languages'),
-        ),
-        ListView.builder(
+            child: const Text('Identify Language'),
+          ),
+          SizedBox(height: 15),
+          ElevatedButton(
+            onPressed: _identifyPossibleLanguages,
+            child: const Text('Identify possible languages'),
+          ),
+          ListView.builder(
             shrinkWrap: true,
             itemCount: _identifiedLanguages.length,
             itemBuilder: (context, index) {
               return ListTile(
                 title: Text(
-                    'Language: ${_identifiedLanguages[index].languageTag}  Confidence: ${_identifiedLanguages[index].confidence.toString()}'),
+                  'Language: ${_identifiedLanguages[index].languageTag}  Confidence: ${_identifiedLanguages[index].confidence.toString()}',
+                ),
               );
-            })
-      ]),
+            },
+          ),
+        ],
+      ),
     );
   }
 
@@ -82,8 +87,8 @@ class _LanguageIdentifierViewState extends State<LanguageIdentifierView> {
     if (_controller.text == '') return;
     String error;
     try {
-      final possibleLanguages =
-          await _languageIdentifier.identifyPossibleLanguages(_controller.text);
+      final possibleLanguages = await _languageIdentifier
+          .identifyPossibleLanguages(_controller.text);
       setState(() {
         _identifiedLanguages = possibleLanguages;
       });

--- a/packages/example/lib/nlp_detector_views/language_translator_view.dart
+++ b/packages/example/lib/nlp_detector_views/language_translator_view.dart
@@ -15,8 +15,9 @@ class _LanguageTranslatorViewState extends State<LanguageTranslatorView> {
   var _sourceLanguage = TranslateLanguage.english;
   var _targetLanguage = TranslateLanguage.spanish;
   var _onDeviceTranslator = OnDeviceTranslator(
-      sourceLanguage: TranslateLanguage.english,
-      targetLanguage: TranslateLanguage.spanish);
+    sourceLanguage: TranslateLanguage.english,
+    targetLanguage: TranslateLanguage.spanish,
+  );
 
   @override
   void dispose() {
@@ -28,9 +29,7 @@ class _LanguageTranslatorViewState extends State<LanguageTranslatorView> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        appBar: AppBar(
-          title: const Text('On-device Translation'),
-        ),
+        appBar: AppBar(title: const Text('On-device Translation')),
         body: GestureDetector(
           onTap: () {
             FocusScope.of(context).unfocus();
@@ -39,24 +38,23 @@ class _LanguageTranslatorViewState extends State<LanguageTranslatorView> {
             children: [
               SizedBox(height: 30),
               Center(
-                  child: Text('Enter text (source: ${_sourceLanguage.name})')),
+                child: Text('Enter text (source: ${_sourceLanguage.name})'),
+              ),
               Padding(
                 padding: const EdgeInsets.all(20.0),
                 child: Row(
                   children: [
                     Expanded(
-                        child: Container(
-                      padding: EdgeInsets.symmetric(horizontal: 20),
-                      decoration: BoxDecoration(
-                          border: Border.all(
-                        width: 2,
-                      )),
-                      child: TextField(
-                        controller: _controller,
-                        decoration: InputDecoration(border: InputBorder.none),
-                        maxLines: null,
+                      child: Container(
+                        padding: EdgeInsets.symmetric(horizontal: 20),
+                        decoration: BoxDecoration(border: Border.all(width: 2)),
+                        child: TextField(
+                          controller: _controller,
+                          decoration: InputDecoration(border: InputBorder.none),
+                          maxLines: null,
+                        ),
                       ),
-                    )),
+                    ),
                     SizedBox(width: 20),
                     _buildDropdown(false),
                   ],
@@ -64,21 +62,21 @@ class _LanguageTranslatorViewState extends State<LanguageTranslatorView> {
               ),
               SizedBox(height: 30),
               Center(
-                  child: Text(
-                      'Translated Text (target: ${_targetLanguage.name})')),
+                child: Text(
+                  'Translated Text (target: ${_targetLanguage.name})',
+                ),
+              ),
               Padding(
                 padding: const EdgeInsets.all(20.0),
                 child: Row(
                   children: [
                     Expanded(
                       child: Container(
-                          width: MediaQuery.of(context).size.width / 1.3,
-                          padding: EdgeInsets.all(20),
-                          decoration: BoxDecoration(
-                              border: Border.all(
-                            width: 2,
-                          )),
-                          child: Text(_translatedText ?? '')),
+                        width: MediaQuery.of(context).size.width / 1.3,
+                        padding: EdgeInsets.all(20),
+                        decoration: BoxDecoration(border: Border.all(width: 2)),
+                        child: Text(_translatedText ?? ''),
+                      ),
                     ),
                     SizedBox(width: 20),
                     _buildDropdown(true),
@@ -86,20 +84,13 @@ class _LanguageTranslatorViewState extends State<LanguageTranslatorView> {
                 ),
               ),
               SizedBox(height: 30),
-              Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                ElevatedButton(
-                    onPressed: _translateText, child: Text('Translate'))
-              ]),
-              SizedBox(height: 20),
               Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   ElevatedButton(
-                      onPressed: _downloadSourceModel,
-                      child: Text('Download Source Model')),
-                  ElevatedButton(
-                      onPressed: _downloadTargetModel,
-                      child: Text('Download Target Model')),
+                    onPressed: _translateText,
+                    child: Text('Translate'),
+                  ),
                 ],
               ),
               SizedBox(height: 20),
@@ -107,11 +98,13 @@ class _LanguageTranslatorViewState extends State<LanguageTranslatorView> {
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
                   ElevatedButton(
-                      onPressed: _deleteSourceModel,
-                      child: Text('Delete Source Model')),
+                    onPressed: _downloadSourceModel,
+                    child: Text('Download Source Model'),
+                  ),
                   ElevatedButton(
-                      onPressed: _deleteTargetModel,
-                      child: Text('Delete Target Model')),
+                    onPressed: _downloadTargetModel,
+                    child: Text('Download Target Model'),
+                  ),
                 ],
               ),
               SizedBox(height: 20),
@@ -119,11 +112,27 @@ class _LanguageTranslatorViewState extends State<LanguageTranslatorView> {
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
                   ElevatedButton(
-                      onPressed: _isSourceModelDownloaded,
-                      child: Text('Source Downloaded?')),
+                    onPressed: _deleteSourceModel,
+                    child: Text('Delete Source Model'),
+                  ),
                   ElevatedButton(
-                      onPressed: _isTargetModelDownloaded,
-                      child: Text('Target Downloaded?')),
+                    onPressed: _deleteTargetModel,
+                    child: Text('Delete Target Model'),
+                  ),
+                ],
+              ),
+              SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  ElevatedButton(
+                    onPressed: _isSourceModelDownloaded,
+                    child: Text('Source Downloaded?'),
+                  ),
+                  ElevatedButton(
+                    onPressed: _isTargetModelDownloaded,
+                    child: Text('Target Downloaded?'),
+                  ),
                 ],
               ),
             ],
@@ -134,106 +143,111 @@ class _LanguageTranslatorViewState extends State<LanguageTranslatorView> {
   }
 
   Widget _buildDropdown(bool isTarget) => DropdownButton<String>(
-        value: (isTarget ? _targetLanguage : _sourceLanguage).bcpCode,
-        icon: const Icon(Icons.arrow_downward),
-        elevation: 16,
-        style: const TextStyle(color: Colors.blue),
-        underline: Container(
-          height: 2,
-          color: Colors.blue,
-        ),
-        onChanged: (String? code) {
-          if (code != null) {
-            final lang = BCP47Code.fromRawValue(code);
-            if (lang != null) {
-              setState(() {
-                isTarget ? _targetLanguage = lang : _sourceLanguage = lang;
-                _onDeviceTranslator = OnDeviceTranslator(
-                    sourceLanguage: _sourceLanguage,
-                    targetLanguage: _targetLanguage);
-              });
-            }
-          }
-        },
-        items: TranslateLanguage.values.map<DropdownMenuItem<String>>((lang) {
-          return DropdownMenuItem<String>(
-            value: lang.bcpCode,
-            child: Text(lang.name),
-          );
-        }).toList(),
+    value: (isTarget ? _targetLanguage : _sourceLanguage).bcpCode,
+    icon: const Icon(Icons.arrow_downward),
+    elevation: 16,
+    style: const TextStyle(color: Colors.blue),
+    underline: Container(height: 2, color: Colors.blue),
+    onChanged: (String? code) {
+      if (code != null) {
+        final lang = BCP47Code.fromRawValue(code);
+        if (lang != null) {
+          setState(() {
+            isTarget ? _targetLanguage = lang : _sourceLanguage = lang;
+            _onDeviceTranslator = OnDeviceTranslator(
+              sourceLanguage: _sourceLanguage,
+              targetLanguage: _targetLanguage,
+            );
+          });
+        }
+      }
+    },
+    items: TranslateLanguage.values.map<DropdownMenuItem<String>>((lang) {
+      return DropdownMenuItem<String>(
+        value: lang.bcpCode,
+        child: Text(lang.name),
       );
+    }).toList(),
+  );
 
   Future<void> _downloadSourceModel() async {
     Toast().show(
-        'Downloading model (${_sourceLanguage.name})...',
-        _modelManager
-            .downloadModel(_sourceLanguage.bcpCode)
-            .then((value) => value ? 'success' : 'failed'),
-        context,
-        this);
+      'Downloading model (${_sourceLanguage.name})...',
+      _modelManager
+          .downloadModel(_sourceLanguage.bcpCode)
+          .then((value) => value ? 'success' : 'failed'),
+      context,
+      this,
+    );
   }
 
   Future<void> _downloadTargetModel() async {
     Toast().show(
-        'Downloading model (${_targetLanguage.name})...',
-        _modelManager
-            .downloadModel(_targetLanguage.bcpCode)
-            .then((value) => value ? 'success' : 'failed'),
-        context,
-        this);
+      'Downloading model (${_targetLanguage.name})...',
+      _modelManager
+          .downloadModel(_targetLanguage.bcpCode)
+          .then((value) => value ? 'success' : 'failed'),
+      context,
+      this,
+    );
   }
 
   Future<void> _deleteSourceModel() async {
     Toast().show(
-        'Deleting model (${_sourceLanguage.name})...',
-        _modelManager
-            .deleteModel(_sourceLanguage.bcpCode)
-            .then((value) => value ? 'success' : 'failed'),
-        context,
-        this);
+      'Deleting model (${_sourceLanguage.name})...',
+      _modelManager
+          .deleteModel(_sourceLanguage.bcpCode)
+          .then((value) => value ? 'success' : 'failed'),
+      context,
+      this,
+    );
   }
 
   Future<void> _deleteTargetModel() async {
     Toast().show(
-        'Deleting model (${_targetLanguage.name})...',
-        _modelManager
-            .deleteModel(_targetLanguage.bcpCode)
-            .then((value) => value ? 'success' : 'failed'),
-        context,
-        this);
+      'Deleting model (${_targetLanguage.name})...',
+      _modelManager
+          .deleteModel(_targetLanguage.bcpCode)
+          .then((value) => value ? 'success' : 'failed'),
+      context,
+      this,
+    );
   }
 
   Future<void> _isSourceModelDownloaded() async {
     Toast().show(
-        'Checking if model (${_sourceLanguage.name}) is downloaded...',
-        _modelManager
-            .isModelDownloaded(_sourceLanguage.bcpCode)
-            .then((value) => value ? 'downloaded' : 'not downloaded'),
-        context,
-        this);
+      'Checking if model (${_sourceLanguage.name}) is downloaded...',
+      _modelManager
+          .isModelDownloaded(_sourceLanguage.bcpCode)
+          .then((value) => value ? 'downloaded' : 'not downloaded'),
+      context,
+      this,
+    );
   }
 
   Future<void> _isTargetModelDownloaded() async {
     Toast().show(
-        'Checking if model (${_targetLanguage.name}) is downloaded...',
-        _modelManager
-            .isModelDownloaded(_targetLanguage.bcpCode)
-            .then((value) => value ? 'downloaded' : 'not downloaded'),
-        context,
-        this);
+      'Checking if model (${_targetLanguage.name}) is downloaded...',
+      _modelManager
+          .isModelDownloaded(_targetLanguage.bcpCode)
+          .then((value) => value ? 'downloaded' : 'not downloaded'),
+      context,
+      this,
+    );
   }
 
   Future<void> _translateText() async {
     FocusScope.of(context).unfocus();
     Toast().show(
-        'Translating...',
-        _onDeviceTranslator.translateText(_controller.text).then((result) {
-          setState(() {
-            _translatedText = result;
-          });
-          return 'done!';
-        }),
-        context,
-        this);
+      'Translating...',
+      _onDeviceTranslator.translateText(_controller.text).then((result) {
+        setState(() {
+          _translatedText = result;
+        });
+        return 'done!';
+      }),
+      context,
+      this,
+    );
   }
 }

--- a/packages/example/lib/nlp_detector_views/smart_reply_view.dart
+++ b/packages/example/lib/nlp_detector_views/smart_reply_view.dart
@@ -23,9 +23,7 @@ class _SmartReplyViewState extends State<SmartReplyView> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Smart Reply'),
-        ),
+        appBar: AppBar(title: const Text('Smart Reply')),
         body: GestureDetector(
           onTap: () {
             FocusScope.of(context).unfocus();
@@ -40,10 +38,7 @@ class _SmartReplyViewState extends State<SmartReplyView> {
                   padding: const EdgeInsets.symmetric(vertical: 20),
                   child: Container(
                     padding: EdgeInsets.symmetric(horizontal: 20),
-                    decoration: BoxDecoration(
-                        border: Border.all(
-                      width: 2,
-                    )),
+                    decoration: BoxDecoration(border: Border.all(width: 2)),
                     child: TextField(
                       controller: _localUserController,
                       decoration: InputDecoration(border: InputBorder.none),
@@ -53,8 +48,9 @@ class _SmartReplyViewState extends State<SmartReplyView> {
                 ),
                 Center(
                   child: ElevatedButton(
-                      onPressed: () => _addMessage(_localUserController, true),
-                      child: Text('Add message to conversation')),
+                    onPressed: () => _addMessage(_localUserController, true),
+                    child: Text('Add message to conversation'),
+                  ),
                 ),
                 SizedBox(height: 30),
                 Text('Remote User:'),
@@ -62,10 +58,7 @@ class _SmartReplyViewState extends State<SmartReplyView> {
                   padding: const EdgeInsets.symmetric(vertical: 20),
                   child: Container(
                     padding: EdgeInsets.symmetric(horizontal: 20),
-                    decoration: BoxDecoration(
-                        border: Border.all(
-                      width: 2,
-                    )),
+                    decoration: BoxDecoration(border: Border.all(width: 2)),
                     child: TextField(
                       controller: _remoteUserController,
                       decoration: InputDecoration(border: InputBorder.none),
@@ -75,27 +68,30 @@ class _SmartReplyViewState extends State<SmartReplyView> {
                 ),
                 Center(
                   child: ElevatedButton(
-                      onPressed: () =>
-                          _addMessage(_remoteUserController, false),
-                      child: Text('Add message to conversation')),
+                    onPressed: () => _addMessage(_remoteUserController, false),
+                    child: Text('Add message to conversation'),
+                  ),
                 ),
                 SizedBox(height: 30),
                 Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      if (_smartReply.conversation.isNotEmpty)
-                        ElevatedButton(
-                            onPressed: () {
-                              _smartReply.clearConversation();
-                              setState(() {
-                                _suggestions = null;
-                              });
-                            },
-                            child: Text('Clear conversation')),
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    if (_smartReply.conversation.isNotEmpty)
                       ElevatedButton(
-                          onPressed: _suggestReplies,
-                          child: Text('Get Suggest Replies')),
-                    ]),
+                        onPressed: () {
+                          _smartReply.clearConversation();
+                          setState(() {
+                            _suggestions = null;
+                          });
+                        },
+                        child: Text('Clear conversation'),
+                      ),
+                    ElevatedButton(
+                      onPressed: _suggestReplies,
+                      child: Text('Get Suggest Replies'),
+                    ),
+                  ],
+                ),
                 SizedBox(height: 30),
                 if (_suggestions != null)
                   Text('Status: ${_suggestions!.status.name}'),
@@ -116,17 +112,24 @@ class _SmartReplyViewState extends State<SmartReplyView> {
     if (controller.text.isNotEmpty) {
       if (localUser) {
         _smartReply.addMessageToConversationFromLocalUser(
-            controller.text, DateTime.now().millisecondsSinceEpoch);
+          controller.text,
+          DateTime.now().millisecondsSinceEpoch,
+        );
       } else {
         _smartReply.addMessageToConversationFromRemoteUser(
-            controller.text, DateTime.now().millisecondsSinceEpoch, 'userZ');
+          controller.text,
+          DateTime.now().millisecondsSinceEpoch,
+          'userZ',
+        );
       }
       controller.text = '';
       ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Message added to the conversation')));
+        SnackBar(content: Text('Message added to the conversation')),
+      );
     } else {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Message can\'t be empty')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Message can\'t be empty')));
     }
   }
 

--- a/packages/example/lib/vision_detector_views/camera_view.dart
+++ b/packages/example/lib/vision_detector_views/camera_view.dart
@@ -6,14 +6,15 @@ import 'package:flutter/services.dart';
 import 'package:google_mlkit_commons/google_mlkit_commons.dart';
 
 class CameraView extends StatefulWidget {
-  CameraView(
-      {super.key,
-      required this.customPaint,
-      required this.onImage,
-      this.onCameraFeedReady,
-      this.onDetectorViewModeChanged,
-      this.onCameraLensDirectionChanged,
-      this.initialCameraLensDirection = CameraLensDirection.back});
+  CameraView({
+    super.key,
+    required this.customPaint,
+    required this.onImage,
+    this.onCameraFeedReady,
+    this.onDetectorViewModeChanged,
+    this.onCameraLensDirectionChanged,
+    this.initialCameraLensDirection = CameraLensDirection.back,
+  });
 
   final CustomPaint? customPaint;
   final Function(InputImage inputImage) onImage;
@@ -82,13 +83,8 @@ class _CameraViewState extends State<CameraView> {
         children: <Widget>[
           Center(
             child: _changingCameraLens
-                ? Center(
-                    child: const Text('Changing camera lens'),
-                  )
-                : CameraPreview(
-                    _controller!,
-                    child: widget.customPaint,
-                  ),
+                ? Center(child: const Text('Changing camera lens'))
+                : CameraPreview(_controller!, child: widget.customPaint),
           ),
           _backButton(),
           _switchLiveCameraToggle(),
@@ -101,120 +97,84 @@ class _CameraViewState extends State<CameraView> {
   }
 
   Widget _backButton() => Positioned(
-        top: 40,
-        left: 8,
-        child: SizedBox(
-          height: 50.0,
-          width: 50.0,
-          child: FloatingActionButton(
-            heroTag: Object(),
-            onPressed: () => Navigator.of(context).pop(),
-            backgroundColor: Colors.black54,
-            child: Icon(
-              Icons.arrow_back_ios_outlined,
-              size: 20,
-            ),
-          ),
-        ),
-      );
+    top: 40,
+    left: 8,
+    child: SizedBox(
+      height: 50.0,
+      width: 50.0,
+      child: FloatingActionButton(
+        heroTag: Object(),
+        onPressed: () => Navigator.of(context).pop(),
+        backgroundColor: Colors.black54,
+        child: Icon(Icons.arrow_back_ios_outlined, size: 20),
+      ),
+    ),
+  );
 
   Widget _detectionViewModeToggle() => Positioned(
-        bottom: 8,
-        left: 8,
-        child: SizedBox(
-          height: 50.0,
-          width: 50.0,
-          child: FloatingActionButton(
-            heroTag: Object(),
-            onPressed: widget.onDetectorViewModeChanged,
-            backgroundColor: Colors.black54,
-            child: Icon(
-              Icons.photo_library_outlined,
-              size: 25,
-            ),
-          ),
-        ),
-      );
+    bottom: 8,
+    left: 8,
+    child: SizedBox(
+      height: 50.0,
+      width: 50.0,
+      child: FloatingActionButton(
+        heroTag: Object(),
+        onPressed: widget.onDetectorViewModeChanged,
+        backgroundColor: Colors.black54,
+        child: Icon(Icons.photo_library_outlined, size: 25),
+      ),
+    ),
+  );
 
   Widget _switchLiveCameraToggle() => Positioned(
-        bottom: 8,
-        right: 8,
-        child: SizedBox(
-          height: 50.0,
-          width: 50.0,
-          child: FloatingActionButton(
-            heroTag: Object(),
-            onPressed: _switchLiveCamera,
-            backgroundColor: Colors.black54,
-            child: Icon(
-              Platform.isIOS
-                  ? Icons.flip_camera_ios_outlined
-                  : Icons.flip_camera_android_outlined,
-              size: 25,
-            ),
-          ),
+    bottom: 8,
+    right: 8,
+    child: SizedBox(
+      height: 50.0,
+      width: 50.0,
+      child: FloatingActionButton(
+        heroTag: Object(),
+        onPressed: _switchLiveCamera,
+        backgroundColor: Colors.black54,
+        child: Icon(
+          Platform.isIOS
+              ? Icons.flip_camera_ios_outlined
+              : Icons.flip_camera_android_outlined,
+          size: 25,
         ),
-      );
+      ),
+    ),
+  );
 
   Widget _zoomControl() => Positioned(
-        bottom: 16,
-        left: 0,
-        right: 0,
-        child: Align(
-          alignment: Alignment.bottomCenter,
-          child: SizedBox(
-            width: 250,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Expanded(
-                  child: Slider(
-                    value: _currentZoomLevel,
-                    min: _minAvailableZoom,
-                    max: _maxAvailableZoom,
-                    activeColor: Colors.white,
-                    inactiveColor: Colors.white30,
-                    onChanged: (value) async {
-                      setState(() {
-                        _currentZoomLevel = value;
-                      });
-                      await _controller?.setZoomLevel(value);
-                    },
-                  ),
-                ),
-                Container(
-                  width: 50,
-                  decoration: BoxDecoration(
-                    color: Colors.black54,
-                    borderRadius: BorderRadius.circular(10.0),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Center(
-                      child: Text(
-                        '${_currentZoomLevel.toStringAsFixed(1)}x',
-                        style: TextStyle(color: Colors.white),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
+    bottom: 16,
+    left: 0,
+    right: 0,
+    child: Align(
+      alignment: Alignment.bottomCenter,
+      child: SizedBox(
+        width: 250,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              child: Slider(
+                value: _currentZoomLevel,
+                min: _minAvailableZoom,
+                max: _maxAvailableZoom,
+                activeColor: Colors.white,
+                inactiveColor: Colors.white30,
+                onChanged: (value) async {
+                  setState(() {
+                    _currentZoomLevel = value;
+                  });
+                  await _controller?.setZoomLevel(value);
+                },
+              ),
             ),
-          ),
-        ),
-      );
-
-  Widget _exposureControl() => Positioned(
-        top: 40,
-        right: 8,
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            maxHeight: 250,
-          ),
-          child: Column(children: [
             Container(
-              width: 55,
+              width: 50,
               decoration: BoxDecoration(
                 color: Colors.black54,
                 borderRadius: BorderRadius.circular(10.0),
@@ -223,36 +183,66 @@ class _CameraViewState extends State<CameraView> {
                 padding: const EdgeInsets.all(8.0),
                 child: Center(
                   child: Text(
-                    '${_currentExposureOffset.toStringAsFixed(1)}x',
+                    '${_currentZoomLevel.toStringAsFixed(1)}x',
                     style: TextStyle(color: Colors.white),
                   ),
                 ),
               ),
             ),
-            Expanded(
-              child: RotatedBox(
-                quarterTurns: 3,
-                child: SizedBox(
-                  height: 30,
-                  child: Slider(
-                    value: _currentExposureOffset,
-                    min: _minAvailableExposureOffset,
-                    max: _maxAvailableExposureOffset,
-                    activeColor: Colors.white,
-                    inactiveColor: Colors.white30,
-                    onChanged: (value) async {
-                      setState(() {
-                        _currentExposureOffset = value;
-                      });
-                      await _controller?.setExposureOffset(value);
-                    },
-                  ),
+          ],
+        ),
+      ),
+    ),
+  );
+
+  Widget _exposureControl() => Positioned(
+    top: 40,
+    right: 8,
+    child: ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: 250),
+      child: Column(
+        children: [
+          Container(
+            width: 55,
+            decoration: BoxDecoration(
+              color: Colors.black54,
+              borderRadius: BorderRadius.circular(10.0),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Center(
+                child: Text(
+                  '${_currentExposureOffset.toStringAsFixed(1)}x',
+                  style: TextStyle(color: Colors.white),
                 ),
               ),
-            )
-          ]),
-        ),
-      );
+            ),
+          ),
+          Expanded(
+            child: RotatedBox(
+              quarterTurns: 3,
+              child: SizedBox(
+                height: 30,
+                child: Slider(
+                  value: _currentExposureOffset,
+                  min: _minAvailableExposureOffset,
+                  max: _maxAvailableExposureOffset,
+                  activeColor: Colors.white,
+                  inactiveColor: Colors.white30,
+                  onChanged: (value) async {
+                    setState(() {
+                      _currentExposureOffset = value;
+                    });
+                    await _controller?.setExposureOffset(value);
+                  },
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
 
   Future _startLiveFeed() async {
     final camera = _cameras[_cameraIndex];
@@ -365,7 +355,7 @@ class _CameraViewState extends State<CameraView> {
     const androidSupportedFormats = [
       InputImageFormat.nv21,
       InputImageFormat.yv12,
-      InputImageFormat.yuv_420_888
+      InputImageFormat.yuv_420_888,
     ];
 
     if ((Platform.isAndroid && !androidSupportedFormats.contains(format)) ||

--- a/packages/example/lib/vision_detector_views/detector_view.dart
+++ b/packages/example/lib/vision_detector_views/detector_view.dart
@@ -59,7 +59,8 @@ class _DetectorViewState extends State<DetectorView> {
             title: widget.title,
             text: widget.text,
             onImage: widget.onImage,
-            onDetectorViewModeChanged: _onDetectorViewModeChanged);
+            onDetectorViewModeChanged: _onDetectorViewModeChanged,
+          );
   }
 
   void _onDetectorViewModeChanged() {

--- a/packages/example/lib/vision_detector_views/digital_ink_recognizer_view.dart
+++ b/packages/example/lib/vision_detector_views/digital_ink_recognizer_view.dart
@@ -89,15 +89,18 @@ class _DigitalInkViewState extends State<DigitalInkView> {
                 onPanUpdate: (DragUpdateDetails details) {
                   setState(() {
                     final RenderObject? object = context.findRenderObject();
-                    final localPosition = (object as RenderBox?)
-                        ?.globalToLocal(details.localPosition);
+                    final localPosition = (object as RenderBox?)?.globalToLocal(
+                      details.localPosition,
+                    );
                     if (localPosition != null) {
                       _points = List.from(_points)
-                        ..add(StrokePoint(
-                          x: localPosition.dx,
-                          y: localPosition.dy,
-                          t: DateTime.now().millisecondsSinceEpoch,
-                        ));
+                        ..add(
+                          StrokePoint(
+                            x: localPosition.dx,
+                            y: localPosition.dy,
+                            t: DateTime.now().millisecondsSinceEpoch,
+                          ),
+                        );
                     }
                     if (_ink.strokes.isNotEmpty) {
                       _ink.strokes.last.points = _points.toList();
@@ -126,31 +129,24 @@ class _DigitalInkViewState extends State<DigitalInkView> {
   }
 
   Widget _buildDropdown() => DropdownButton<String>(
-        value: _language,
-        icon: const Icon(Icons.arrow_downward),
-        elevation: 16,
-        style: const TextStyle(color: Colors.blue),
-        underline: Container(
-          height: 2,
-          color: Colors.blue,
-        ),
-        onChanged: (String? lang) {
-          if (lang != null) {
-            setState(() {
-              _language = lang;
-              _digitalInkRecognizer.close();
-              _digitalInkRecognizer =
-                  DigitalInkRecognizer(languageCode: _language);
-            });
-          }
-        },
-        items: _languages.map<DropdownMenuItem<String>>((lang) {
-          return DropdownMenuItem<String>(
-            value: lang,
-            child: Text(lang),
-          );
-        }).toList(),
-      );
+    value: _language,
+    icon: const Icon(Icons.arrow_downward),
+    elevation: 16,
+    style: const TextStyle(color: Colors.blue),
+    underline: Container(height: 2, color: Colors.blue),
+    onChanged: (String? lang) {
+      if (lang != null) {
+        setState(() {
+          _language = lang;
+          _digitalInkRecognizer.close();
+          _digitalInkRecognizer = DigitalInkRecognizer(languageCode: _language);
+        });
+      }
+    },
+    items: _languages.map<DropdownMenuItem<String>>((lang) {
+      return DropdownMenuItem<String>(value: lang, child: Text(lang));
+    }).toList(),
+  );
 
   void _clearPad() {
     setState(() {
@@ -162,41 +158,43 @@ class _DigitalInkViewState extends State<DigitalInkView> {
 
   Future<void> _isModelDownloaded() async {
     Toast().show(
-        'Checking if model is downloaded...',
-        _modelManager
-            .isModelDownloaded(_language)
-            .then((value) => value ? 'downloaded' : 'not downloaded'),
-        context,
-        this);
+      'Checking if model is downloaded...',
+      _modelManager
+          .isModelDownloaded(_language)
+          .then((value) => value ? 'downloaded' : 'not downloaded'),
+      context,
+      this,
+    );
   }
 
   Future<void> _deleteModel() async {
     Toast().show(
-        'Deleting model...',
-        _modelManager
-            .deleteModel(_language)
-            .then((value) => value ? 'success' : 'failed'),
-        context,
-        this);
+      'Deleting model...',
+      _modelManager
+          .deleteModel(_language)
+          .then((value) => value ? 'success' : 'failed'),
+      context,
+      this,
+    );
   }
 
   Future<void> _downloadModel() async {
     Toast().show(
-        'Downloading model...',
-        _modelManager
-            .downloadModel(_language)
-            .then((value) => value ? 'success' : 'failed'),
-        context,
-        this);
+      'Downloading model...',
+      _modelManager
+          .downloadModel(_language)
+          .then((value) => value ? 'success' : 'failed'),
+      context,
+      this,
+    );
   }
 
   Future<void> _recogniseText() async {
     showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-              title: Text('Recognizing'),
-            ),
-        barrierDismissible: true);
+      context: context,
+      builder: (context) => AlertDialog(title: Text('Recognizing')),
+      barrierDismissible: true,
+    );
     try {
       final candidates = await _digitalInkRecognizer.recognize(_ink);
       _recognizedText = '';
@@ -205,9 +203,9 @@ class _DigitalInkViewState extends State<DigitalInkView> {
       }
       setState(() {});
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(e.toString()),
-      ));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(e.toString())));
     }
     Navigator.pop(context);
   }
@@ -229,8 +227,11 @@ class Signature extends CustomPainter {
       for (int i = 0; i < stroke.points.length - 1; i++) {
         final p1 = stroke.points[i];
         final p2 = stroke.points[i + 1];
-        canvas.drawLine(Offset(p1.x.toDouble(), p1.y.toDouble()),
-            Offset(p2.x.toDouble(), p2.y.toDouble()), paint);
+        canvas.drawLine(
+          Offset(p1.x.toDouble(), p1.y.toDouble()),
+          Offset(p2.x.toDouble(), p2.y.toDouble()),
+          paint,
+        );
       }
     }
   }

--- a/packages/example/lib/vision_detector_views/document_scanner_view.dart
+++ b/packages/example/lib/vision_detector_views/document_scanner_view.dart
@@ -17,10 +17,13 @@ class _DocumentScannerViewState extends State<DocumentScannerView> {
   DocumentScanner? _documentScanner;
   DocumentScanningResult? _result;
   static final List<MenuEntry> menuEntries = UnmodifiableListView<MenuEntry>(
-      list.map<MenuEntry>((String name) => MenuEntry(
-          value: name,
-          label:
-              name == 'Select option' ? name : 'Scan ${name.toUpperCase()}')));
+    list.map<MenuEntry>(
+      (String name) => MenuEntry(
+        value: name,
+        label: name == 'Select option' ? name : 'Scan ${name.toUpperCase()}',
+      ),
+    ),
+  );
   @override
   void dispose() {
     _documentScanner?.close();
@@ -43,37 +46,39 @@ class _DocumentScannerViewState extends State<DocumentScannerView> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(
-                    Icons.document_scanner_outlined,
-                    size: 50,
-                  ),
+                  Icon(Icons.document_scanner_outlined, size: 50),
                   SizedBox(width: 8),
                   DropdownMenu<String>(
-                      initialSelection: list.first,
-                      onSelected: (String? value) {
-                        if (value != null) {
-                          if (value == 'pdf') {
-                            startScan({DocumentFormat.pdf});
-                          }
-                          if (value == 'jpeg') {
-                            startScan({DocumentFormat.jpeg});
-                          }
-                          if (value == 'pdf-jpeg') {
-                            startScan(
-                                {DocumentFormat.pdf, DocumentFormat.jpeg});
-                          }
+                    initialSelection: list.first,
+                    onSelected: (String? value) {
+                      if (value != null) {
+                        if (value == 'pdf') {
+                          startScan({DocumentFormat.pdf});
                         }
-                      },
-                      dropdownMenuEntries: menuEntries),
+                        if (value == 'jpeg') {
+                          startScan({DocumentFormat.jpeg});
+                        }
+                        if (value == 'pdf-jpeg') {
+                          startScan({DocumentFormat.pdf, DocumentFormat.jpeg});
+                        }
+                      }
+                    },
+                    dropdownMenuEntries: menuEntries,
+                  ),
                 ],
               ),
               if (_result?.pdf != null) ...[
                 Padding(
                   padding: const EdgeInsets.only(
-                      top: 16, bottom: 8, right: 8, left: 8),
+                    top: 16,
+                    bottom: 8,
+                    right: 8,
+                    left: 8,
+                  ),
                   child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: Text('PDF Document:')),
+                    alignment: Alignment.centerLeft,
+                    child: Text('PDF Document:'),
+                  ),
                 ),
                 SizedBox(
                   height: 300,
@@ -89,14 +94,20 @@ class _DocumentScannerViewState extends State<DocumentScannerView> {
               if (_result?.images?.isNotEmpty == true) ...[
                 Padding(
                   padding: const EdgeInsets.only(
-                      top: 16, bottom: 8, right: 8, left: 8),
+                    top: 16,
+                    bottom: 8,
+                    right: 8,
+                    left: 8,
+                  ),
                   child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: Text('Images [0]:')),
+                    alignment: Alignment.centerLeft,
+                    child: Text('Images [0]:'),
+                  ),
                 ),
                 SizedBox(
-                    height: 400,
-                    child: Image.file(File(_result!.images!.first))),
+                  height: 400,
+                  child: Image.file(File(_result!.images!.first)),
+                ),
               ],
             ],
           ),

--- a/packages/example/lib/vision_detector_views/face_detector_view.dart
+++ b/packages/example/lib/vision_detector_views/face_detector_view.dart
@@ -12,10 +12,7 @@ class FaceDetectorView extends StatefulWidget {
 
 class _FaceDetectorViewState extends State<FaceDetectorView> {
   final FaceDetector _faceDetector = FaceDetector(
-    options: FaceDetectorOptions(
-      enableContours: true,
-      enableLandmarks: true,
-    ),
+    options: FaceDetectorOptions(enableContours: true, enableLandmarks: true),
   );
   bool _canProcess = true;
   bool _isBusy = false;

--- a/packages/example/lib/vision_detector_views/face_mesh_detector_view.dart
+++ b/packages/example/lib/vision_detector_views/face_mesh_detector_view.dart
@@ -13,8 +13,9 @@ class FaceMeshDetectorView extends StatefulWidget {
 }
 
 class _FaceMeshDetectorViewState extends State<FaceMeshDetectorView> {
-  final FaceMeshDetector _meshDetector =
-      FaceMeshDetector(option: FaceMeshDetectorOptions.faceMesh);
+  final FaceMeshDetector _meshDetector = FaceMeshDetector(
+    option: FaceMeshDetectorOptions.faceMesh,
+  );
   bool _canProcess = true;
   bool _isBusy = false;
   CustomPaint? _customPaint;
@@ -34,10 +35,11 @@ class _FaceMeshDetectorViewState extends State<FaceMeshDetectorView> {
       return Scaffold(
         appBar: AppBar(title: Text('Under construction')),
         body: Center(
-            child: Text(
-          'Not implemented yet for iOS :(\nTry Android',
-          textAlign: TextAlign.center,
-        )),
+          child: Text(
+            'Not implemented yet for iOS :(\nTry Android',
+            textAlign: TextAlign.center,
+          ),
+        ),
       );
     }
     return DetectorView(

--- a/packages/example/lib/vision_detector_views/gallery_view.dart
+++ b/packages/example/lib/vision_detector_views/gallery_view.dart
@@ -8,12 +8,13 @@ import 'package:image_picker/image_picker.dart';
 import 'utils.dart';
 
 class GalleryView extends StatefulWidget {
-  GalleryView(
-      {super.key,
-      required this.title,
-      this.text,
-      required this.onImage,
-      required this.onDetectorViewModeChanged});
+  GalleryView({
+    super.key,
+    required this.title,
+    this.text,
+    required this.onImage,
+    required this.onDetectorViewModeChanged,
+  });
 
   final String title;
   final String? text;
@@ -39,68 +40,68 @@ class _GalleryViewState extends State<GalleryView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: Text(widget.title),
-          actions: [
-            Padding(
-              padding: EdgeInsets.only(right: 20.0),
-              child: GestureDetector(
-                onTap: widget.onDetectorViewModeChanged,
-                child: Icon(
-                  Platform.isIOS ? Icons.camera_alt_outlined : Icons.camera,
-                ),
+      appBar: AppBar(
+        title: Text(widget.title),
+        actions: [
+          Padding(
+            padding: EdgeInsets.only(right: 20.0),
+            child: GestureDetector(
+              onTap: widget.onDetectorViewModeChanged,
+              child: Icon(
+                Platform.isIOS ? Icons.camera_alt_outlined : Icons.camera,
               ),
             ),
-          ],
-        ),
-        body: _galleryBody());
+          ),
+        ],
+      ),
+      body: _galleryBody(),
+    );
   }
 
   Widget _galleryBody() {
-    return ListView(shrinkWrap: true, children: [
-      _image != null
-          ? SizedBox(
-              height: 400,
-              width: 400,
-              child: Stack(
-                fit: StackFit.expand,
-                children: <Widget>[
-                  Image.file(_image!),
-                ],
-              ),
-            )
-          : Icon(
-              Icons.image,
-              size: 200,
-            ),
-      Padding(
-        padding: EdgeInsets.symmetric(horizontal: 16),
-        child: ElevatedButton(
-          onPressed: _getImageAsset,
-          child: Text('From Assets'),
-        ),
-      ),
-      Padding(
-        padding: EdgeInsets.symmetric(horizontal: 16),
-        child: ElevatedButton(
-          child: Text('From Gallery'),
-          onPressed: () => _getImage(ImageSource.gallery),
-        ),
-      ),
-      Padding(
-        padding: EdgeInsets.symmetric(horizontal: 16),
-        child: ElevatedButton(
-          child: Text('Take a picture'),
-          onPressed: () => _getImage(ImageSource.camera),
-        ),
-      ),
-      if (_image != null)
+    return ListView(
+      shrinkWrap: true,
+      children: [
+        _image != null
+            ? SizedBox(
+                height: 400,
+                width: 400,
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: <Widget>[Image.file(_image!)],
+                ),
+              )
+            : Icon(Icons.image, size: 200),
         Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Text(
-              '${_path == null ? '' : 'Image path: $_path'}\n\n${widget.text ?? ''}'),
+          padding: EdgeInsets.symmetric(horizontal: 16),
+          child: ElevatedButton(
+            onPressed: _getImageAsset,
+            child: Text('From Assets'),
+          ),
         ),
-    ]);
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16),
+          child: ElevatedButton(
+            child: Text('From Gallery'),
+            onPressed: () => _getImage(ImageSource.gallery),
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16),
+          child: ElevatedButton(
+            child: Text('Take a picture'),
+            onPressed: () => _getImage(ImageSource.camera),
+          ),
+        ),
+        if (_image != null)
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(
+              '${_path == null ? '' : 'Image path: $_path'}\n\n${widget.text ?? ''}',
+            ),
+          ),
+      ],
+    );
   }
 
   Future _getImage(ImageSource source) async {
@@ -119,57 +120,60 @@ class _GalleryViewState extends State<GalleryView> {
     final List<String> assets = assetManifest
         .listAssets()
         .where((String key) => key.contains('images/'))
-        .where((String key) =>
-            key.contains('.jpg') ||
-            key.contains('.jpeg') ||
-            key.contains('.png') ||
-            key.contains('.webp'))
+        .where(
+          (String key) =>
+              key.contains('.jpg') ||
+              key.contains('.jpeg') ||
+              key.contains('.png') ||
+              key.contains('.webp'),
+        )
         .toList();
 
     showDialog(
-        context: context,
-        builder: (BuildContext context) {
-          return Dialog(
-            shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(30.0)),
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    'Select image',
-                    style: TextStyle(fontSize: 20),
+      context: context,
+      builder: (BuildContext context) {
+        return Dialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(30.0),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Select image', style: TextStyle(fontSize: 20)),
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxHeight: MediaQuery.of(context).size.height * 0.7,
                   ),
-                  ConstrainedBox(
-                    constraints: BoxConstraints(
-                        maxHeight: MediaQuery.of(context).size.height * 0.7),
-                    child: SingleChildScrollView(
-                      child: Column(
-                        children: [
-                          for (final path in assets)
-                            GestureDetector(
-                              onTap: () async {
-                                Navigator.of(context).pop();
-                                _processFile(await getAssetPath(path));
-                              },
-                              child: Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Image.asset(path),
-                              ),
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        for (final path in assets)
+                          GestureDetector(
+                            onTap: () async {
+                              Navigator.of(context).pop();
+                              _processFile(await getAssetPath(path));
+                            },
+                            child: Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Image.asset(path),
                             ),
-                        ],
-                      ),
+                          ),
+                      ],
                     ),
                   ),
-                  ElevatedButton(
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: Text('Cancel')),
-                ],
-              ),
+                ),
+                ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text('Cancel'),
+                ),
+              ],
             ),
-          );
-        });
+          ),
+        );
+      },
+    );
   }
 
   Future _processFile(String path) async {

--- a/packages/example/lib/vision_detector_views/label_detector_view.dart
+++ b/packages/example/lib/vision_detector_views/label_detector_view.dart
@@ -82,7 +82,8 @@ class _ImageLabelViewState extends State<ImageLabelView> {
     } else {
       String text = 'Labels found: ${labels.length}\n\n';
       for (final label in labels) {
-        text += 'Label: ${label.label}, '
+        text +=
+            'Label: ${label.label}, '
             'Confidence: ${label.confidence.toStringAsFixed(2)}\n\n';
       }
       _text = text;

--- a/packages/example/lib/vision_detector_views/object_detector_view.dart
+++ b/packages/example/lib/vision_detector_views/object_detector_view.dart
@@ -26,17 +26,17 @@ class _ObjectDetectorView extends State<ObjectDetectorView> {
     'fruits': 'object_labeler_fruits.tflite',
     'flowers': 'object_labeler_flowers.tflite',
     'birds': 'lite-model_aiy_vision_classifier_birds_V1_3.tflite',
+
     // https://tfhub.dev/google/lite-model/aiy/vision/classifier/birds_V1/3
-
     'food': 'lite-model_aiy_vision_classifier_food_V1_1.tflite',
+
     // https://tfhub.dev/google/lite-model/aiy/vision/classifier/food_V1/1
-
     'plants': 'lite-model_aiy_vision_classifier_plants_V1_3.tflite',
+
     // https://tfhub.dev/google/lite-model/aiy/vision/classifier/plants_V1/3
-
     'mushrooms': 'lite-model_models_mushroom-identification_v1_1.tflite',
-    // https://tfhub.dev/bohemian-visual-recognition-alliance/lite-model/models/mushroom-identification_v1/1
 
+    // https://tfhub.dev/bohemian-visual-recognition-alliance/lite-model/models/mushroom-identification_v1/1
     'landmarks':
         'lite-model_on_device_vision_classifier_landmarks_classifier_north_america_V1_1.tflite',
     // https://tfhub.dev/google/lite-model/on_device_vision/classifier/landmarks_classifier_north_america_V1/1
@@ -52,19 +52,21 @@ class _ObjectDetectorView extends State<ObjectDetectorView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Stack(children: [
-        DetectorView(
-          title: 'Object Detector',
-          customPaint: _customPaint,
-          text: _text,
-          onImage: _processImage,
-          initialCameraLensDirection: _cameraLensDirection,
-          onCameraLensDirectionChanged: (value) => _cameraLensDirection = value,
-          onCameraFeedReady: _initializeDetector,
-          initialDetectionMode: DetectorViewMode.values[_mode.index],
-          onDetectorViewModeChanged: _onScreenModeChanged,
-        ),
-        Positioned(
+      body: Stack(
+        children: [
+          DetectorView(
+            title: 'Object Detector',
+            customPaint: _customPaint,
+            text: _text,
+            onImage: _processImage,
+            initialCameraLensDirection: _cameraLensDirection,
+            onCameraLensDirectionChanged: (value) =>
+                _cameraLensDirection = value,
+            onCameraFeedReady: _initializeDetector,
+            initialDetectionMode: DetectorViewMode.values[_mode.index],
+            onDetectorViewModeChanged: _onScreenModeChanged,
+          ),
+          Positioned(
             top: 30,
             left: 100,
             right: 100,
@@ -72,46 +74,47 @@ class _ObjectDetectorView extends State<ObjectDetectorView> {
               children: [
                 Spacer(),
                 Container(
-                    decoration: BoxDecoration(
-                      color: Colors.black54,
-                      borderRadius: BorderRadius.circular(10.0),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(4.0),
-                      child: _buildDropdown(),
-                    )),
+                  decoration: BoxDecoration(
+                    color: Colors.black54,
+                    borderRadius: BorderRadius.circular(10.0),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(4.0),
+                    child: _buildDropdown(),
+                  ),
+                ),
                 Spacer(),
               ],
-            )),
-      ]),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
   Widget _buildDropdown() => DropdownButton<int>(
-        value: _option,
-        icon: const Icon(Icons.arrow_downward),
-        elevation: 16,
-        style: const TextStyle(color: Colors.blue),
-        underline: Container(
-          height: 2,
-          color: Colors.blue,
-        ),
-        onChanged: (int? option) {
-          if (option != null) {
-            setState(() {
-              _option = option;
-              _initializeDetector();
-            });
-          }
-        },
-        items: List<int>.generate(_options.length, (i) => i)
-            .map<DropdownMenuItem<int>>((option) {
+    value: _option,
+    icon: const Icon(Icons.arrow_downward),
+    elevation: 16,
+    style: const TextStyle(color: Colors.blue),
+    underline: Container(height: 2, color: Colors.blue),
+    onChanged: (int? option) {
+      if (option != null) {
+        setState(() {
+          _option = option;
+          _initializeDetector();
+        });
+      }
+    },
+    items: List<int>.generate(_options.length, (i) => i)
+        .map<DropdownMenuItem<int>>((option) {
           return DropdownMenuItem<int>(
             value: option,
             child: Text(_options.keys.toList()[option]),
           );
-        }).toList(),
-      );
+        })
+        .toList(),
+  );
 
   void _onScreenModeChanged(DetectorViewMode mode) {
     switch (mode) {

--- a/packages/example/lib/vision_detector_views/painters/barcode_detector_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/barcode_detector_painter.dart
@@ -33,12 +33,14 @@ class BarcodeDetectorPainter extends CustomPainter {
     for (final Barcode barcode in barcodes) {
       final ParagraphBuilder builder = ParagraphBuilder(
         ParagraphStyle(
-            textAlign: TextAlign.left,
-            fontSize: 16,
-            textDirection: TextDirection.ltr),
+          textAlign: TextAlign.left,
+          fontSize: 16,
+          textDirection: TextDirection.ltr,
+        ),
       );
       builder.pushStyle(
-          ui.TextStyle(color: Colors.lightGreenAccent, background: background));
+        ui.TextStyle(color: Colors.lightGreenAccent, background: background),
+      );
       builder.addText('${barcode.displayValue}');
       builder.pop();
 
@@ -103,15 +105,13 @@ class BarcodeDetectorPainter extends CustomPainter {
 
       canvas.drawParagraph(
         builder.build()
-          ..layout(ParagraphConstraints(
-            width: (right - left).abs(),
-          )),
+          ..layout(ParagraphConstraints(width: (right - left).abs())),
         Offset(
-            Platform.isAndroid &&
-                    cameraLensDirection == CameraLensDirection.front
-                ? right
-                : left,
-            top),
+          Platform.isAndroid && cameraLensDirection == CameraLensDirection.front
+              ? right
+              : left,
+          top,
+        ),
       );
     }
   }

--- a/packages/example/lib/vision_detector_views/painters/face_detector_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/face_detector_painter.dart
@@ -60,34 +60,32 @@ class FaceDetectorPainter extends CustomPainter {
         cameraLensDirection,
       );
 
-      canvas.drawRect(
-        Rect.fromLTRB(left, top, right, bottom),
-        paint1,
-      );
+      canvas.drawRect(Rect.fromLTRB(left, top, right, bottom), paint1);
 
       void paintContour(FaceContourType type) {
         final contour = face.contours[type];
         if (contour?.points != null) {
           for (final Point point in contour!.points) {
             canvas.drawCircle(
-                Offset(
-                  translateX(
-                    point.x.toDouble(),
-                    size,
-                    imageSize,
-                    rotation,
-                    cameraLensDirection,
-                  ),
-                  translateY(
-                    point.y.toDouble(),
-                    size,
-                    imageSize,
-                    rotation,
-                    cameraLensDirection,
-                  ),
+              Offset(
+                translateX(
+                  point.x.toDouble(),
+                  size,
+                  imageSize,
+                  rotation,
+                  cameraLensDirection,
                 ),
-                1,
-                paint1);
+                translateY(
+                  point.y.toDouble(),
+                  size,
+                  imageSize,
+                  rotation,
+                  cameraLensDirection,
+                ),
+              ),
+              1,
+              paint1,
+            );
           }
         }
       }
@@ -96,24 +94,25 @@ class FaceDetectorPainter extends CustomPainter {
         final landmark = face.landmarks[type];
         if (landmark?.position != null) {
           canvas.drawCircle(
-              Offset(
-                translateX(
-                  landmark!.position.x.toDouble(),
-                  size,
-                  imageSize,
-                  rotation,
-                  cameraLensDirection,
-                ),
-                translateY(
-                  landmark.position.y.toDouble(),
-                  size,
-                  imageSize,
-                  rotation,
-                  cameraLensDirection,
-                ),
+            Offset(
+              translateX(
+                landmark!.position.x.toDouble(),
+                size,
+                imageSize,
+                rotation,
+                cameraLensDirection,
               ),
-              2,
-              paint2);
+              translateY(
+                landmark.position.y.toDouble(),
+                size,
+                imageSize,
+                rotation,
+                cameraLensDirection,
+              ),
+            ),
+            2,
+            paint2,
+          );
         }
       }
 

--- a/packages/example/lib/vision_detector_views/painters/face_mesh_detector_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/face_mesh_detector_painter.dart
@@ -60,10 +60,7 @@ class FaceMeshDetectorPainter extends CustomPainter {
         cameraLensDirection,
       );
 
-      canvas.drawRect(
-        Rect.fromLTRB(left, top, right, bottom),
-        paint1,
-      );
+      canvas.drawRect(Rect.fromLTRB(left, top, right, bottom), paint1);
 
       void paintTriangle(FaceMeshTriangle triangle) {
         final List<Offset> cornerPoints = <Offset>[];

--- a/packages/example/lib/vision_detector_views/painters/label_detector_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/label_detector_painter.dart
@@ -12,23 +12,23 @@ class LabelDetectorPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final ui.ParagraphBuilder builder = ui.ParagraphBuilder(
       ui.ParagraphStyle(
-          textAlign: TextAlign.left,
-          fontSize: 23,
-          textDirection: TextDirection.ltr),
+        textAlign: TextAlign.left,
+        fontSize: 23,
+        textDirection: TextDirection.ltr,
+      ),
     );
 
     builder.pushStyle(ui.TextStyle(color: Colors.lightBlue[900]));
     for (final ImageLabel label in labels) {
-      builder.addText('Label: ${label.label}, '
-          'Confidence: ${label.confidence.toStringAsFixed(2)}\n');
+      builder.addText(
+        'Label: ${label.label}, '
+        'Confidence: ${label.confidence.toStringAsFixed(2)}\n',
+      );
     }
     builder.pop();
 
     canvas.drawParagraph(
-      builder.build()
-        ..layout(ui.ParagraphConstraints(
-          width: size.width,
-        )),
+      builder.build()..layout(ui.ParagraphConstraints(width: size.width)),
       const Offset(0, 0),
     );
   }

--- a/packages/example/lib/vision_detector_views/painters/object_detector_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/object_detector_painter.dart
@@ -33,15 +33,18 @@ class ObjectDetectorPainter extends CustomPainter {
     for (final DetectedObject detectedObject in _objects) {
       final ParagraphBuilder builder = ParagraphBuilder(
         ParagraphStyle(
-            textAlign: TextAlign.left,
-            fontSize: 16,
-            textDirection: TextDirection.ltr),
+          textAlign: TextAlign.left,
+          fontSize: 16,
+          textDirection: TextDirection.ltr,
+        ),
       );
       builder.pushStyle(
-          ui.TextStyle(color: Colors.lightGreenAccent, background: background));
+        ui.TextStyle(color: Colors.lightGreenAccent, background: background),
+      );
       if (detectedObject.labels.isNotEmpty) {
-        final label = detectedObject.labels
-            .reduce((a, b) => a.confidence > b.confidence ? a : b);
+        final label = detectedObject.labels.reduce(
+          (a, b) => a.confidence > b.confidence ? a : b,
+        );
         builder.addText('${label.text} ${label.confidence}\n');
       }
       builder.pop();
@@ -75,22 +78,17 @@ class ObjectDetectorPainter extends CustomPainter {
         cameraLensDirection,
       );
 
-      canvas.drawRect(
-        Rect.fromLTRB(left, top, right, bottom),
-        paint,
-      );
+      canvas.drawRect(Rect.fromLTRB(left, top, right, bottom), paint);
 
       canvas.drawParagraph(
         builder.build()
-          ..layout(ParagraphConstraints(
-            width: (right - left).abs(),
-          )),
+          ..layout(ParagraphConstraints(width: (right - left).abs())),
         Offset(
-            Platform.isAndroid &&
-                    cameraLensDirection == CameraLensDirection.front
-                ? right
-                : left,
-            top),
+          Platform.isAndroid && cameraLensDirection == CameraLensDirection.front
+              ? right
+              : left,
+          top,
+        ),
       );
     }
   }

--- a/packages/example/lib/vision_detector_views/painters/pose_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/pose_painter.dart
@@ -37,88 +37,122 @@ class PosePainter extends CustomPainter {
     for (final pose in poses) {
       pose.landmarks.forEach((_, landmark) {
         canvas.drawCircle(
-            Offset(
-              translateX(
-                landmark.x,
-                size,
-                imageSize,
-                rotation,
-                cameraLensDirection,
-              ),
-              translateY(
-                landmark.y,
-                size,
-                imageSize,
-                rotation,
-                cameraLensDirection,
-              ),
+          Offset(
+            translateX(
+              landmark.x,
+              size,
+              imageSize,
+              rotation,
+              cameraLensDirection,
             ),
-            1,
-            paint);
+            translateY(
+              landmark.y,
+              size,
+              imageSize,
+              rotation,
+              cameraLensDirection,
+            ),
+          ),
+          1,
+          paint,
+        );
       });
 
       void paintLine(
-          PoseLandmarkType type1, PoseLandmarkType type2, Paint paintType) {
+        PoseLandmarkType type1,
+        PoseLandmarkType type2,
+        Paint paintType,
+      ) {
         final PoseLandmark joint1 = pose.landmarks[type1]!;
         final PoseLandmark joint2 = pose.landmarks[type2]!;
         canvas.drawLine(
-            Offset(
-                translateX(
-                  joint1.x,
-                  size,
-                  imageSize,
-                  rotation,
-                  cameraLensDirection,
-                ),
-                translateY(
-                  joint1.y,
-                  size,
-                  imageSize,
-                  rotation,
-                  cameraLensDirection,
-                )),
-            Offset(
-                translateX(
-                  joint2.x,
-                  size,
-                  imageSize,
-                  rotation,
-                  cameraLensDirection,
-                ),
-                translateY(
-                  joint2.y,
-                  size,
-                  imageSize,
-                  rotation,
-                  cameraLensDirection,
-                )),
-            paintType);
+          Offset(
+            translateX(
+              joint1.x,
+              size,
+              imageSize,
+              rotation,
+              cameraLensDirection,
+            ),
+            translateY(
+              joint1.y,
+              size,
+              imageSize,
+              rotation,
+              cameraLensDirection,
+            ),
+          ),
+          Offset(
+            translateX(
+              joint2.x,
+              size,
+              imageSize,
+              rotation,
+              cameraLensDirection,
+            ),
+            translateY(
+              joint2.y,
+              size,
+              imageSize,
+              rotation,
+              cameraLensDirection,
+            ),
+          ),
+          paintType,
+        );
       }
 
       //Draw arms
       paintLine(
-          PoseLandmarkType.leftShoulder, PoseLandmarkType.leftElbow, leftPaint);
+        PoseLandmarkType.leftShoulder,
+        PoseLandmarkType.leftElbow,
+        leftPaint,
+      );
       paintLine(
-          PoseLandmarkType.leftElbow, PoseLandmarkType.leftWrist, leftPaint);
-      paintLine(PoseLandmarkType.rightShoulder, PoseLandmarkType.rightElbow,
-          rightPaint);
+        PoseLandmarkType.leftElbow,
+        PoseLandmarkType.leftWrist,
+        leftPaint,
+      );
       paintLine(
-          PoseLandmarkType.rightElbow, PoseLandmarkType.rightWrist, rightPaint);
+        PoseLandmarkType.rightShoulder,
+        PoseLandmarkType.rightElbow,
+        rightPaint,
+      );
+      paintLine(
+        PoseLandmarkType.rightElbow,
+        PoseLandmarkType.rightWrist,
+        rightPaint,
+      );
 
       //Draw Body
       paintLine(
-          PoseLandmarkType.leftShoulder, PoseLandmarkType.leftHip, leftPaint);
-      paintLine(PoseLandmarkType.rightShoulder, PoseLandmarkType.rightHip,
-          rightPaint);
+        PoseLandmarkType.leftShoulder,
+        PoseLandmarkType.leftHip,
+        leftPaint,
+      );
+      paintLine(
+        PoseLandmarkType.rightShoulder,
+        PoseLandmarkType.rightHip,
+        rightPaint,
+      );
 
       //Draw legs
       paintLine(PoseLandmarkType.leftHip, PoseLandmarkType.leftKnee, leftPaint);
       paintLine(
-          PoseLandmarkType.leftKnee, PoseLandmarkType.leftAnkle, leftPaint);
+        PoseLandmarkType.leftKnee,
+        PoseLandmarkType.leftAnkle,
+        leftPaint,
+      );
       paintLine(
-          PoseLandmarkType.rightHip, PoseLandmarkType.rightKnee, rightPaint);
+        PoseLandmarkType.rightHip,
+        PoseLandmarkType.rightKnee,
+        rightPaint,
+      );
       paintLine(
-          PoseLandmarkType.rightKnee, PoseLandmarkType.rightAnkle, rightPaint);
+        PoseLandmarkType.rightKnee,
+        PoseLandmarkType.rightAnkle,
+        rightPaint,
+      );
     }
   }
 

--- a/packages/example/lib/vision_detector_views/painters/subject_segmentation_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/subject_segmentation_painter.dart
@@ -36,20 +36,20 @@ class SubjectSegmentationPainter extends CustomPainter {
           final int absoluteY = startY;
 
           final int tx = translateX(
-                  absoluteX.toDouble(),
-                  size,
-                  Size(imageSize.width.toDouble(), imageSize.height.toDouble()),
-                  rotation,
-                  cameraLensDirection)
-              .round();
+            absoluteX.toDouble(),
+            size,
+            Size(imageSize.width.toDouble(), imageSize.height.toDouble()),
+            rotation,
+            cameraLensDirection,
+          ).round();
 
           final int ty = translateY(
-                  absoluteY.toDouble(),
-                  size,
-                  Size(imageSize.width.toDouble(), imageSize.height.toDouble()),
-                  rotation,
-                  cameraLensDirection)
-              .round();
+            absoluteY.toDouble(),
+            size,
+            Size(imageSize.width.toDouble(), imageSize.height.toDouble()),
+            rotation,
+            cameraLensDirection,
+          ).round();
 
           final double opacity = confidences[(y * subjectWidth) + x] * 0.5;
           paint.color = color.withAlpha((opacity * 255).round());

--- a/packages/example/lib/vision_detector_views/painters/text_detector_painter.dart
+++ b/packages/example/lib/vision_detector_views/painters/text_detector_painter.dart
@@ -33,12 +33,14 @@ class TextRecognizerPainter extends CustomPainter {
     for (final textBlock in recognizedText.blocks) {
       final ParagraphBuilder builder = ParagraphBuilder(
         ParagraphStyle(
-            textAlign: TextAlign.left,
-            fontSize: 16,
-            textDirection: TextDirection.ltr),
+          textAlign: TextAlign.left,
+          fontSize: 16,
+          textDirection: TextDirection.ltr,
+        ),
       );
       builder.pushStyle(
-          ui.TextStyle(color: Colors.lightGreenAccent, background: background));
+        ui.TextStyle(color: Colors.lightGreenAccent, background: background),
+      );
       builder.addText(textBlock.text);
       builder.pop();
 
@@ -112,7 +114,8 @@ class TextRecognizerPainter extends CustomPainter {
                     rotation,
                     cameraLensDirection,
                   );
-                  y = size.height -
+                  y =
+                      size.height -
                       translateY(
                         point.x.toDouble(),
                         size,
@@ -133,7 +136,8 @@ class TextRecognizerPainter extends CustomPainter {
                   y = size.height - y;
                   break;
                 case InputImageRotation.rotation90deg:
-                  x = size.width -
+                  x =
+                      size.width -
                       translateX(
                         point.y.toDouble(),
                         size,
@@ -165,15 +169,13 @@ class TextRecognizerPainter extends CustomPainter {
 
       canvas.drawParagraph(
         builder.build()
-          ..layout(ParagraphConstraints(
-            width: (right - left).abs(),
-          )),
+          ..layout(ParagraphConstraints(width: (right - left).abs())),
         Offset(
-            Platform.isAndroid &&
-                    cameraLensDirection == CameraLensDirection.front
-                ? right
-                : left,
-            top),
+          Platform.isAndroid && cameraLensDirection == CameraLensDirection.front
+              ? right
+              : left,
+          top,
+        ),
       );
     }
   }

--- a/packages/example/lib/vision_detector_views/pose_detector_view.dart
+++ b/packages/example/lib/vision_detector_views/pose_detector_view.dart
@@ -12,8 +12,9 @@ class PoseDetectorView extends StatefulWidget {
 }
 
 class _PoseDetectorViewState extends State<PoseDetectorView> {
-  final PoseDetector _poseDetector =
-      PoseDetector(options: PoseDetectorOptions());
+  final PoseDetector _poseDetector = PoseDetector(
+    options: PoseDetectorOptions(),
+  );
   bool _canProcess = true;
   bool _isBusy = false;
   CustomPaint? _customPaint;

--- a/packages/example/lib/vision_detector_views/subject_segmenter_view.dart
+++ b/packages/example/lib/vision_detector_views/subject_segmenter_view.dart
@@ -53,8 +53,9 @@ class _SubjectSegmenterViewState extends State<SubjectSegmenterView> {
     setState(() {
       _text = '';
     });
-    final SubjectSegmentationResult mask =
-        await _segmenter.processImage(inputImage);
+    final SubjectSegmentationResult mask = await _segmenter.processImage(
+      inputImage,
+    );
     if (inputImage.metadata?.size != null &&
         inputImage.metadata?.rotation != null) {
       final painter = SubjectSegmentationPainter(

--- a/packages/example/lib/vision_detector_views/text_detector_view.dart
+++ b/packages/example/lib/vision_detector_views/text_detector_view.dart
@@ -29,16 +29,18 @@ class _TextRecognizerViewState extends State<TextRecognizerView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Stack(children: [
-        DetectorView(
-          title: 'Text Detector',
-          customPaint: _customPaint,
-          text: _text,
-          onImage: _processImage,
-          initialCameraLensDirection: _cameraLensDirection,
-          onCameraLensDirectionChanged: (value) => _cameraLensDirection = value,
-        ),
-        Positioned(
+      body: Stack(
+        children: [
+          DetectorView(
+            title: 'Text Detector',
+            customPaint: _customPaint,
+            text: _text,
+            onImage: _processImage,
+            initialCameraLensDirection: _cameraLensDirection,
+            onCameraLensDirectionChanged: (value) =>
+                _cameraLensDirection = value,
+          ),
+          Positioned(
             top: 30,
             left: 100,
             right: 100,
@@ -46,47 +48,48 @@ class _TextRecognizerViewState extends State<TextRecognizerView> {
               children: [
                 Spacer(),
                 Container(
-                    decoration: BoxDecoration(
-                      color: Colors.black54,
-                      borderRadius: BorderRadius.circular(10.0),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(4.0),
-                      child: _buildDropdown(),
-                    )),
+                  decoration: BoxDecoration(
+                    color: Colors.black54,
+                    borderRadius: BorderRadius.circular(10.0),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(4.0),
+                    child: _buildDropdown(),
+                  ),
+                ),
                 Spacer(),
               ],
-            )),
-      ]),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
   Widget _buildDropdown() => DropdownButton<TextRecognitionScript>(
-        value: _script,
-        icon: const Icon(Icons.arrow_downward),
-        elevation: 16,
-        style: const TextStyle(color: Colors.blue),
-        underline: Container(
-          height: 2,
-          color: Colors.blue,
-        ),
-        onChanged: (TextRecognitionScript? script) {
-          if (script != null) {
-            setState(() {
-              _script = script;
-              _textRecognizer.close();
-              _textRecognizer = TextRecognizer(script: _script);
-            });
-          }
-        },
-        items: TextRecognitionScript.values
-            .map<DropdownMenuItem<TextRecognitionScript>>((script) {
+    value: _script,
+    icon: const Icon(Icons.arrow_downward),
+    elevation: 16,
+    style: const TextStyle(color: Colors.blue),
+    underline: Container(height: 2, color: Colors.blue),
+    onChanged: (TextRecognitionScript? script) {
+      if (script != null) {
+        setState(() {
+          _script = script;
+          _textRecognizer.close();
+          _textRecognizer = TextRecognizer(script: _script);
+        });
+      }
+    },
+    items: TextRecognitionScript.values
+        .map<DropdownMenuItem<TextRecognitionScript>>((script) {
           return DropdownMenuItem<TextRecognitionScript>(
             value: script,
             child: Text(script.name),
           );
-        }).toList(),
-      );
+        })
+        .toList(),
+  );
 
   Future<void> _processImage(InputImage inputImage) async {
     if (!_canProcess) return;

--- a/packages/example/lib/vision_detector_views/text_from_widget_view.dart
+++ b/packages/example/lib/vision_detector_views/text_from_widget_view.dart
@@ -28,9 +28,7 @@ class _TextFromWidgetViewState extends State<TextFromWidgetView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Text From Widget Example'),
-      ),
+      appBar: AppBar(title: const Text('Text From Widget Example')),
       body: Column(
         children: [
           Expanded(
@@ -98,8 +96,9 @@ class _TextFromWidgetViewState extends State<TextFromWidgetView> {
 
     try {
       // Get the RenderObject from the GlobalKey
-      final RenderRepaintBoundary? boundary = _widgetKey.currentContext
-          ?.findRenderObject() as RenderRepaintBoundary?;
+      final RenderRepaintBoundary? boundary =
+          _widgetKey.currentContext?.findRenderObject()
+              as RenderRepaintBoundary?;
 
       if (boundary == null) {
         setState(() {
@@ -113,8 +112,9 @@ class _TextFromWidgetViewState extends State<TextFromWidgetView> {
       final ui.Image image = await boundary.toImage(pixelRatio: 3.0);
 
       // Convert to byte data in raw RGBA format
-      final ByteData? byteData =
-          await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      final ByteData? byteData = await image.toByteData(
+        format: ui.ImageByteFormat.rawRgba,
+      );
 
       if (byteData == null) {
         setState(() {
@@ -134,8 +134,9 @@ class _TextFromWidgetViewState extends State<TextFromWidgetView> {
       );
 
       // Process the image with the text recognizer
-      final RecognizedText recognizedText =
-          await _textRecognizer.processImage(inputImage);
+      final RecognizedText recognizedText = await _textRecognizer.processImage(
+        inputImage,
+      );
 
       setState(() {
         _extractedText = recognizedText.text.isNotEmpty

--- a/packages/example/lib/vision_detector_views/utils.dart
+++ b/packages/example/lib/vision_detector_views/utils.dart
@@ -10,8 +10,12 @@ Future<String> getAssetPath(String asset) async {
   final file = File(path);
   if (!await file.exists()) {
     final byteData = await rootBundle.load(asset);
-    await file.writeAsBytes(byteData.buffer
-        .asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
+    await file.writeAsBytes(
+      byteData.buffer.asUint8List(
+        byteData.offsetInBytes,
+        byteData.lengthInBytes,
+      ),
+    );
   }
   return file.path;
 }

--- a/packages/example/pubspec.lock
+++ b/packages/example/pubspec.lock
@@ -656,5 +656,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/packages/example/pubspec.yaml
+++ b/packages/example/pubspec.yaml
@@ -7,8 +7,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
-  flutter: '>=3.22.0'
+  sdk: ^3.12.0
+  flutter: '>=3.44.0'
 
 dependencies:
   camera: ^0.11.1

--- a/packages/google_ml_kit/pubspec.yaml
+++ b/packages/google_ml_kit/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_ml_kit
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_barcode_scanning/android/build.gradle
+++ b/packages/google_mlkit_barcode_scanning/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_barcode_scanning"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20")
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_barcode_scanning"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_barcode_scanning/pubspec.yaml
+++ b/packages/google_mlkit_barcode_scanning/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_barcode_scanning
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_commons/android/build.gradle
+++ b/packages/google_mlkit_commons/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_commons"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20")
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_commons"
@@ -34,10 +37,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
     
-    kotlinOptions {
-        jvmTarget = '11'
-    }
-
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
     }

--- a/packages/google_mlkit_commons/pubspec.yaml
+++ b/packages/google_mlkit_commons/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_commons
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_digital_ink_recognition/android/build.gradle
+++ b/packages/google_mlkit_digital_ink_recognition/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_digital_ink_recognition"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_digital_ink_recognition"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_digital_ink_recognition/pubspec.yaml
+++ b/packages/google_mlkit_digital_ink_recognition/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_digital_ink_recognition
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_document_scanner/android/build.gradle
+++ b/packages/google_mlkit_document_scanner/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_document_scanner"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_document_scanner"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_document_scanner/pubspec.yaml
+++ b/packages/google_mlkit_document_scanner/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_document_scanner
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_entity_extraction/android/build.gradle
+++ b/packages/google_mlkit_entity_extraction/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_entity_extraction"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_entity_extraction"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_entity_extraction/pubspec.yaml
+++ b/packages/google_mlkit_entity_extraction/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_entity_extraction
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_face_detection/android/build.gradle
+++ b/packages/google_mlkit_face_detection/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_face_detection"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_face_detection"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_face_detection/pubspec.yaml
+++ b/packages/google_mlkit_face_detection/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_face_detection
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_face_mesh_detection/android/build.gradle
+++ b/packages/google_mlkit_face_mesh_detection/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_face_mesh_detection"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_face_mesh_detection"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_face_mesh_detection/pubspec.yaml
+++ b/packages/google_mlkit_face_mesh_detection/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_face_mesh_detection
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_genai_image_description/android/build.gradle
+++ b/packages/google_mlkit_genai_image_description/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_genai_image_description"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_genai_image_description"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_genai_image_description/pubspec.yaml
+++ b/packages/google_mlkit_genai_image_description/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_genai_image_description
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_genai_prompt/android/build.gradle
+++ b/packages/google_mlkit_genai_prompt/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_genai_prompt"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_genai_prompt"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_genai_prompt/pubspec.yaml
+++ b/packages/google_mlkit_genai_prompt/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_genai_prompt
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_genai_proofreading/android/build.gradle
+++ b/packages/google_mlkit_genai_proofreading/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_genai_proofreading"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_genai_proofreading"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_genai_proofreading/pubspec.yaml
+++ b/packages/google_mlkit_genai_proofreading/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_genai_proofreading
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_genai_rewriting/android/build.gradle
+++ b/packages/google_mlkit_genai_rewriting/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_genai_rewriting"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_genai_rewriting"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_genai_rewriting/pubspec.yaml
+++ b/packages/google_mlkit_genai_rewriting/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_genai_rewriting
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_genai_speech_recognition/android/build.gradle
+++ b/packages/google_mlkit_genai_speech_recognition/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_genai_speech_recognition"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_genai_speech_recognition"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_genai_speech_recognition/pubspec.yaml
+++ b/packages/google_mlkit_genai_speech_recognition/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_genai_speech_recognition
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_genai_summarization/android/build.gradle
+++ b/packages/google_mlkit_genai_summarization/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_genai_summarization"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_genai_summarization"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_genai_summarization/pubspec.yaml
+++ b/packages/google_mlkit_genai_summarization/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_genai_summarization
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_image_labeling/android/build.gradle
+++ b/packages/google_mlkit_image_labeling/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_image_labeling"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_image_labeling"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_image_labeling/pubspec.yaml
+++ b/packages/google_mlkit_image_labeling/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_image_labeling
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_language_id/android/build.gradle
+++ b/packages/google_mlkit_language_id/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_language_id"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_language_id"
@@ -33,10 +36,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = '11'
-    }
-
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
     }

--- a/packages/google_mlkit_language_id/pubspec.yaml
+++ b/packages/google_mlkit_language_id/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_language_id
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_object_detection/android/build.gradle
+++ b/packages/google_mlkit_object_detection/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_object_detection"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_object_detection"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_object_detection/pubspec.yaml
+++ b/packages/google_mlkit_object_detection/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_object_detection
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_pose_detection/android/build.gradle
+++ b/packages/google_mlkit_pose_detection/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_pose_detection"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_pose_detection"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_pose_detection/pubspec.yaml
+++ b/packages/google_mlkit_pose_detection/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_pose_detection
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_selfie_segmentation/android/build.gradle
+++ b/packages/google_mlkit_selfie_segmentation/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_selfie_segmentation"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_selfie_segmentation"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_selfie_segmentation/pubspec.yaml
+++ b/packages/google_mlkit_selfie_segmentation/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_selfie_segmentation
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_smart_reply/android/build.gradle
+++ b/packages/google_mlkit_smart_reply/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_smart_reply"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_smart_reply"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_smart_reply/pubspec.yaml
+++ b/packages/google_mlkit_smart_reply/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_smart_reply
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_subject_segmentation/android/build.gradle
+++ b/packages/google_mlkit_subject_segmentation/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_subject_segmentation"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_subject_segmentation"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_subject_segmentation/pubspec.yaml
+++ b/packages/google_mlkit_subject_segmentation/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_subject_segmentation
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_text_recognition/android/build.gradle
+++ b/packages/google_mlkit_text_recognition/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_text_recognition"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_text_recognition"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_text_recognition/pubspec.yaml
+++ b/packages/google_mlkit_text_recognition/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_text_recognition
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/packages/google_mlkit_translation/android/build.gradle
+++ b/packages/google_mlkit_translation/android/build.gradle
@@ -2,7 +2,6 @@ group = "com.google_mlkit_translation"
 version = "1.0"
 
 buildscript {
-    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.13.0")
-        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20')
     }
 }
 
@@ -22,7 +20,12 @@ rootProject.allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
 android {
     namespace = "com.google_mlkit_translation"
@@ -32,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     sourceSets {

--- a/packages/google_mlkit_translation/pubspec.yaml
+++ b/packages/google_mlkit_translation/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/flutter-ml/google_ml_kit_flutter
 repository: https://github.com/flutter-ml/google_ml_kit_flutter/tree/master/packages/google_mlkit_translation
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary

- migrate all 22 Android plugin modules away from applying the Kotlin Gradle Plugin
- replace legacy `kotlinOptions` blocks with `kotlin.compilerOptions`
- raise the package floor to Flutter 3.44 / Dart 3.12, as required by Flutter's migration guide
- migrate the example app and add stable plus Flutter 3.47 beta Android build lanes

Closes #888.

## Validation

- `flutter pub get` succeeds for the full example workspace
- a focused consumer using `google_mlkit_barcode_scanning`, `google_mlkit_commons`, and `google_mlkit_text_recognition` builds a debug APK on Flutter 3.44.8 without the legacy plugin-KGP warning
- all 22 Android plugin build files contain the compiler-options DSL and none applies or declares KGP
- `git diff --check` passes

The full all-package example build progressed through native/Kotlin compilation without an emitted error but exceeded a 15-minute local validation bound. The new CI jobs are intended to complete that matrix, including AGP 9 built-in Kotlin on Flutter 3.47 beta.

## Release note

This intentionally leaves package version and changelog headings to the maintainers so the migration can follow the final pre-Flutter-3.44 compatibility releases discussed in #888. Each migrated package's eventual release notes should mention the Flutter 3.44 / Dart 3.12 minimum and built-in Kotlin migration.
