### PR TITLE
fix: iOS digital ink recognition returns Int score when model omits it

### DIFF
--- a/packages/google_mlkit_digital_ink_recognition/ios/Classes/GoogleMlKitDigitalInkRecognitionPlugin.swift
+++ b/packages/google_mlkit_digital_ink_recognition/ios/Classes/GoogleMlKitDigitalInkRecognitionPlugin.swift
@@ -113,7 +113,7 @@ public class GoogleMlKitDigitalInkRecognitionPlugin: NSObject, FlutterPlugin {
       let candidates = recognitionResult.candidates.map { candidate in
         [
           "text": candidate.text,
-          "score": candidate.score?.doubleValue ?? 0
+          "score": candidate.score?.doubleValue ?? 0.0
         ] as [String: Any]
       }
       result(candidates)


### PR DESCRIPTION
On iOS, `DigitalInkRecognizer.recognize()` throws for every recognition when the
model does not populate `score`:

```
TypeError: type 'int' is not a subtype of type 'double'
  at new RecognitionCandidate.fromJson (digital_ink_recognizer.dart:157)
```

Recognition fails 100% of the time for those models — Korean (`ko`) in our case.
Seen on iPad (iOS 18.3.2), Flutter 3.47, plugin 0.16.1.

## Cause

`GoogleMlKitDigitalInkRecognitionPlugin.swift:116`

```swift
[
  "text": candidate.text,
  "score": candidate.score?.doubleValue ?? 0
] as [String: Any]
```

Inside a `[String: Any]` literal the contextual type is `Any`, so Swift does not
unify the `??` operands to `Double`. When `candidate.score` is `nil` the literal
`0` stays an `Int`, and the standard message codec encodes it as an integer.
`RecognitionCandidate.score` is declared `double`, so the cast fails.

The type therefore depends on the *value*:

```swift
let s: NSNumber? = nil
let d: [String: Any] = ["score": s?.doubleValue ?? 0]
type(of: d["score"]!)   // Int      objCType "q"

let s2: NSNumber? = NSNumber(value: -1.5)
let d2: [String: Any] = ["score": s2?.doubleValue ?? 0]
type(of: d2["score"]!)  // Double   objCType "d"
```

`score` is documented as "populated only for models that support it", so `nil`
is expected, not exceptional.

This is a regression from 0.15.0 (ObjC to Swift rewrite). The Android side and
the previous ObjC implementation both always produce a double:

```kotlin
"score" to (candidate.score?.toDouble() ?: 0.0)          // Kotlin, correct
```

```objc
@{@"score": @(candidate.score.doubleValue)}              // ObjC 0.14.2, correct
```

Android is unaffected — we confirmed recognition still works there on a physical
device with the same app build.

## Fix

Make the fallback a floating-point literal so the expression is `Double`
regardless of whether `score` is present:

```diff
-          "score": candidate.score?.doubleValue ?? 0
+          "score": candidate.score?.doubleValue ?? 0.0
```

Verified with the snippet above: `?? 0.0` yields `Double` / objCType `d` in both
the `nil` and non-`nil` cases.

I checked the other `?? 0` occurrences in the Swift plugins — they assign to
local `let`s with concrete types (`floatValue`, `intValue`), so they are not
affected. This is the only one that crosses the channel inside a
`[String: Any]` literal.
